### PR TITLE
chore: set up codeclimate test report in github ci

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -54,11 +54,9 @@ jobs:
         # CCTR expects a file named cobertura.xml
         run: |
           bundle exec cucumber
-          cp coverage/coverage.xml ./cobertura.xml
-          $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type cobertura
+          $CCTR format-coverage --output coverage/codeclimate.$SUITE.json --input-type simplecov
           bundle exec rspec
-          cp coverage/coverage.xml ./cobertura.xml
-          $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type cobertura
+          $CCTR format-coverage --output coverage/codeclimate.$SUITE.json --input-type simplecov
       - name: CodeCov Coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -53,12 +53,12 @@ jobs:
         # SimpleCov runs with the Cobertura formatter for codeclimate
         # CCTR expects a file named cobertura.xml
         run: |
-          # bundle exec cucumber
+          bundle exec cucumber
+          cp coverage/coverage.xml ./cobertura.xml
           $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type cobertura
+          bundle exec rspec
           cp coverage/coverage.xml ./cobertura.xml
-          # bundle exec rspec
           $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type cobertura
-          cp coverage/coverage.xml ./cobertura.xml
       - name: CodeCov Coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -27,6 +27,7 @@ jobs:
       DISPLAY: ':99' # For chromedriver
       CCTR: ./cc-test-reporter
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -38,6 +39,7 @@ jobs:
         with:
           ruby-version: 2.7.7
           bundler-cache: true
+
       - name: Setup Code Climate
         run: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > $CCTR
@@ -47,20 +49,31 @@ jobs:
       - run: bin/rails webpacker:compile
       - run: bundle exec rake db:setup
       - run: bundle exec rake db:migrate
+
       - name: Run ${{ matrix.suite }}
         # SimpleCov runs with the Cobertura formatter for codeclimate
         # CCTR expects a file named cobertura.xml
         run: |
           bundle exec cucumber
+          $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type simplecov
           cp coverage/coverage.xml ./cobertura.xml
-          $CCTR format-coverage -o coverage/codeclimate.cucumber.json -t cobertura
+        # $CCTR format-coverage -o coverage/codeclimate.cucumber.json -t cobertura
           bundle exec rspec
+          $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type simplecov
           cp coverage/coverage.xml ./cobertura.xml
-          $CCTR format-coverage -o coverage/codeclimate.rspec.json -t cobertura
+        # $CCTR format-coverage -o coverage/codeclimate.rspec.json -t cobertura
+
       - name: CodeCov Coverage
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      
+      - name: Publish code coverage
+        run: |
+          export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+          $CCTR sum-coverage coverage/codeclimate.*.json
+          $CCTR upload-coverage --id $CC_TEST_REPORTER_ID
+          $CCTR after-build --id $CC_TEST_REPORTER_ID
       # - name: Publish Code Climate
       #  run: |
       #    export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -53,11 +53,11 @@ jobs:
         # SimpleCov runs with the Cobertura formatter for codeclimate
         # CCTR expects a file named cobertura.xml
         run: |
-          bundle exec cucumber
-          $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type simplecov
+          # bundle exec cucumber
+          $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type cobertura
           cp coverage/coverage.xml ./cobertura.xml
-          bundle exec rspec
-          $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type simplecov
+          # bundle exec rspec
+          $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type cobertura
           cp coverage/coverage.xml ./cobertura.xml
       - name: CodeCov Coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -27,7 +27,7 @@ jobs:
       DISPLAY: ':99' # For chromedriver
       CCTR: ./cc-test-reporter
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      
+
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -49,7 +49,6 @@ jobs:
       - run: bin/rails webpacker:compile
       - run: bundle exec rake db:setup
       - run: bundle exec rake db:migrate
-
       - name: Run ${{ matrix.suite }}
         # SimpleCov runs with the Cobertura formatter for codeclimate
         # CCTR expects a file named cobertura.xml
@@ -57,17 +56,13 @@ jobs:
           bundle exec cucumber
           $CCTR format-coverage --output coverage/codeclimate.cucumber.json --input-type simplecov
           cp coverage/coverage.xml ./cobertura.xml
-        # $CCTR format-coverage -o coverage/codeclimate.cucumber.json -t cobertura
           bundle exec rspec
           $CCTR format-coverage --output coverage/codeclimate.rspec.json --input-type simplecov
           cp coverage/coverage.xml ./cobertura.xml
-        # $CCTR format-coverage -o coverage/codeclimate.rspec.json -t cobertura
-
       - name: CodeCov Coverage
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      
       - name: Publish code coverage
         run: |
           export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"


### PR DESCRIPTION
Encountered some weird json parsing problem. 
Seems like a compatibility issue. See https://github.com/codeclimate/test-reporter/issues/413#issuecomment-1079155787.

Tried both the cobertura formatter and the simplecov but none worked.