### PR TITLE
Fix Heroku Deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb -p $PORT
-release: bin/rails db:prepare
+release: bin/rails db:schema:load && bin/rails db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
 web: bundle exec puma -C config/puma.rb -p $PORT
-release: bin/rails db:schema:load && bin/rails db:seed
+# release: bin/rails db:schema:load && bin/rails db:seed
+# Temporarily commented out. We do not want to run these commands more than once
+# Instead, when we deploy for the first time we run those manually in console

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,2 @@
 web: bundle exec puma -C config/puma.rb -p $PORT
-# release: bin/rails db:schema:load && bin/rails db:seed
-# Temporarily commented out. We do not want to run these commands more than once
-# Instead, when we deploy for the first time we run those manually in console
+release: bin/rails db:prepare

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ We have worked on the adding following core features and functionality:
 - Make your local changes and start the commit process
 - `git add .`
 - `git commit -m "<Message>"`
-- `git push heroku master`
+- `git push heroku master` (If this fails, try commenting the release command in `Procfile` for this first deployment only and go on to the next step. After you are done with the deployment, uncomment back the release command again. For more information, see [this PR](https://github.com/cs169/BJC-Teacher-Tracker/pull/15).)
 
 If bundler install runs successfully, continue with the following commands to correctly setup the PostgreSQL database on Heroku:
 - `heroku addons:create heroku-postgresql` (or, create and attach a new postgresql database on Heroku dashboard manually)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ We have worked on the adding following core features and functionality:
 - For Rubocop check run `bundle exec rubocop` (Autocorrect all with `bundle exec rubocop -a`)
 - To make someone an admin use db console access
   - Using psql
-    - First run `heroku pg:psql` or `psql bjc_teachers_dev`
+    - First run `heroku pg:psql` (for Heroku) or `psql bjc_teachers_dev` (for local) to get into psql
+    - Alternatively, you can use `rails db` to get into psql
     - Then
       ```
       UPDATE teachers
@@ -86,7 +87,7 @@ We have worked on the adding following core features and functionality:
       ```
       Of course, you can swap in the email of your choice.
   - Using rails console
-    - First run `heroku run rails console` or `rails console` to get into rails console
+    - First run `heroku run rails console` (for Heroku) or `rails console` (for local) to get into rails console
     - Then
       ```
       Teacher.where("email LIKE '%@berkeley.edu%'").update_all(admin: true)

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ If bundler install runs successfully, continue with the following commands to co
 - `heroku open`
 
 
-### CodeClimate Local Test
-
+## CodeClimate Local Test
 
 ```
 https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64

--- a/README.md
+++ b/README.md
@@ -75,14 +75,22 @@ We have worked on the adding following core features and functionality:
 - For Cucumber tests run `bundle exec cucumber`
 - For Rubocop check run `bundle exec rubocop` (Autocorrect all with `bundle exec rubocop -a`)
 - To make someone an admin use db console access
-  - First run `heroku pg:psql` or `psql bjc_teachers_dev`
-  - Then
-    ```
-    UPDATE teachers
-    SET admin = true
-    WHERE Email LIKE '%@berkeley.edu%'
-    ;
-    ```
+  - Using psql
+    - First run `heroku pg:psql` or `psql bjc_teachers_dev`
+    - Then
+      ```
+      UPDATE teachers
+      SET admin = true
+      WHERE Email LIKE '%@berkeley.edu%'
+      ;
+      ```
+      Of course, you can swap in the email of your choice.
+  - Using rails console
+    - First run `heroku run rails console` or `rails console` to get into rails console
+    - Then
+      ```
+      Teacher.where("email LIKE '%@berkeley.edu%'").update_all(admin: true)
+      ```
 
 ## JavaScript and CSS with Webpack
 
@@ -97,20 +105,21 @@ We have worked on the adding following core features and functionality:
 ## Steps to Deploying on Heroku
 
 - ... create a heroku app
+- `heroku stack:set heroku-20` (Ruby 2.7.7 is not supported on latest stack heroku-22. Double check your Ruby version though)
 - `heroku buildpacks:set heroku/nodejs` # this must be the first buildpack.
 - `heroku buildpacks:add --index 2 heroku/ruby`
-- `git remote set-url heroku https://git.heroku.com/bjc-teachers.git`
+- `git remote set-url heroku https://git.heroku.com/bjc-teachers.git` (or whatever your heroku deployment repository is)
 - Make your local changes and start the commit process
 - `git add .`
 - `git commit -m "<Message>"`
 - `git push heroku master`
 
 If bundler install runs successfully, continue with the following commands to correctly setup the PostgreSQL database on Heroku:
-- `heroku addons:create heroku-postgresql`
-- `heroku run rake db:drop`
-- `heroku run rake db:schema:load`
-- `heroku run rake db:migrate`
-- `figaro heroku:set -e production`
+- `heroku addons:create heroku-postgresql` (or, create and attach a new postgresql database on Heroku dashboard manually)
+- `heroku run bin/rails db:drop` (if this fails, you can skip this step)
+- `heroku run bin/rails db:schema:load`
+- `heroku run bin/rails db:seed`
+- `figaro heroku:set -e production` (or `staging`, depending on the your needs)
 - `heroku open`
 
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,3 +8,8 @@ production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: bjc_teacher_tracker_production
+
+staging:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: bjc_teacher_tracker_production

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -12,4 +12,4 @@ production:
 staging:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: bjc_teacher_tracker_production
+  channel_prefix: bjc_teacher_tracker_staging

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,10 +23,10 @@ production:
   adapter: postgresql
   pool: 5
   timeout: 5000
-  database: bjc_teachers_prod
+  database: bjc_teachers_stage
 
 production:
   adapter: postgresql
   pool: 5
   timeout: 5000
-  database: bjc_teachers_stage
+  database: bjc_teachers_prod

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,3 +24,9 @@ production:
   pool: 5
   timeout: 5000
   database: bjc_teachers_prod
+
+production:
+  adapter: postgresql
+  pool: 5
+  timeout: 5000
+  database: bjc_teachers_stage

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ test:
   <<: *default
   database: bjc_teachers_test
 
-production:
+staging:
   adapter: postgresql
   pool: 5
   timeout: 5000

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # config.require_master_key = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Compress JavaScripts and CSS.
+  # config.assets.js_compressor = Uglifier.new(harmony: true)
+  # config.assets.css_compressor = :sass
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Store uploaded files on the local file system (see config/storage.yml for options)
+  # config.active_storage.service = :local
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :warn
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Don't log view information:
+  config.action_view.logger = nil
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "bjc_teacher_tracker_#{Rails.env}"
+
+  config.action_mailer.perform_caching = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # Email settings
+  # Do not send emails in staging environment, and do not raise errors
+  config.action_mailer.raise_delivery_errors = false
+
+  # Store files on Amazon S3. (Uncomment this when S3 is setup)
+  # config.active_storage.service = :amazon
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -27,3 +27,8 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   bjc_password: <%= ENV["BJC_PASSWORD"] %>
   piazza_password: <%= ENV["PIAZZA_PASSWORD"] %>
+
+staging:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  bjc_password: <%= ENV["BJC_PASSWORD"] %>
+  piazza_password: <%= ENV["PIAZZA_PASSWORD"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,12 +23,10 @@ test:
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
-production:
+production: &production
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   bjc_password: <%= ENV["BJC_PASSWORD"] %>
   piazza_password: <%= ENV["PIAZZA_PASSWORD"] %>
 
 staging:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  bjc_password: <%= ENV["BJC_PASSWORD"] %>
-  piazza_password: <%= ENV["PIAZZA_PASSWORD"] %>
+  <<: *production

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -94,3 +94,15 @@ production:
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+staging: 
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true


### PR DESCRIPTION
Created a new staging environment in rails (basically the same to the production environment as close as possible, but with email sender error suppressed and database name changed etc.) This is meant for staging in Heroku so it staging environment does not do things that only production app should do (sending email to clients etc).

I ended up didn't changing anything in Procfile because: 

The right thing to do (for heroku) is just to:
- For the first deployment, comment out release command `db:prepare` and then deploy. Then, run `db:schema:load && bin/rails db:seed` manually on console.
- For all subsequent deployment, we uncomment release command `db:prepare` to allow it to run on subsequent deployments. Not doing so will leads to problems like when we have schema changes (when we add features, for example) that is not applied automatically... then you have to manually run `db:migrate` or `db:prepare` (if you have a db setup and schema loaded prepare basically just do migration). 

Can we simply replace the release command in Procfile to be `db:schema:load && bin/rails db:seed`? No. This will fail all subsequent runs because `db:schema:load` is considered destructive to database and running it a second time will be blocked by rails.

So that is why I ended up uncommenting the original `db:prepare`. Really, making sure `db:prepare` works in all cases (eliminating the edge case of first deployment) is the right thing to do, instead of swapping out command. I am not sure why `db:prepare` failed on the first deployment. Based on logs `db:prepare` on first deployment seems to fail at the migration stage, complaining either missing version number on migration file or missing table.