### PR TITLE
Add Default Page Control and Redirection

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,7 @@ class PagesController < ApplicationController
   def index
     if !current_user && Page.default_page.present?
       redirect_to page_path(Page.default_page.url_slug)
-      return
+      nil
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,8 +7,7 @@ class PagesController < ApplicationController
 
   def index
     if !current_user && Page.default_page.present?
-      redirect_to page_path(Page.default_page.url_slug)
-      nil
+      redirect_to page_path(Page.default_page.url_slug) and return
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,16 +52,6 @@ class PagesController < ApplicationController
   def edit; end
 
   def update
-    # print all params
-    puts "params: #{params}"
-    if page_params[:default] == "1"
-      if page_params[:viewer_permissions] != "Public"
-        flash.now[:alert] = "Default page must be public!"
-        render "edit"
-        return
-      end
-      Page.where.not(id: @page.id).update_all(default: false)
-    end
     @page.assign_attributes(page_params)
     @page.last_editor = current_user
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -29,8 +29,10 @@ class Page < ApplicationRecord
   validates :url_slug, uniqueness: true
   validates :last_editor, :viewer_permissions, :url_slug, :title, :html, :creator_id, presence: true
   validates_inclusion_of :viewer_permissions, in: ["Admin", "Verified Teacher", "Public"]
+  validates_inclusion_of :viewer_permissions, in: ["Public"], if: :default
 
   before_save :fix_bjc_r_links
+  before_save :ensure_only_one_default_page
 
   belongs_to :last_editor, class_name: "Teacher"
   belongs_to :creator, class_name: "Teacher"
@@ -53,11 +55,16 @@ class Page < ApplicationRecord
   def to_param
     self.url_slug
   end
-
+  
   # TODO: This may be a bit too specific?
   def fix_bjc_r_links
     return unless self.html
     self.html = self.html.gsub('="/bjc-r', '="https://bjc.edc.org/bjc-r')
+  end
+
+  def ensure_only_one_default_page
+    return unless self.default
+    Page.where.not(id: self.id).update_all(default: false)
   end
 
   def self.viewable_pages(user)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,6 +5,8 @@
 # Table name: pages
 #
 #  id                 :bigint           not null, primary key
+#  category           :string
+#  default            :boolean
 #  html               :text
 #  title              :string           not null
 #  url_slug           :string           not null

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -42,6 +42,10 @@ class Page < ApplicationRecord
     Page.pluck(:category).uniq
   end
 
+  def self.default_page
+    Page.where(default: true).first
+  end
+
   def has_category?
     self.category.present?
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -43,7 +43,7 @@ class Page < ApplicationRecord
   end
 
   def self.default_page
-    Page.where(default: true).first
+    Page.find_by(default: true)
   end
 
   def has_category?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -55,7 +55,7 @@ class Page < ApplicationRecord
   def to_param
     self.url_slug
   end
-  
+
   # TODO: This may be a bit too specific?
   def fix_bjc_r_links
     return unless self.html

--- a/app/views/pages/_admin_table.html.erb
+++ b/app/views/pages/_admin_table.html.erb
@@ -2,6 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th scope="col">Title</th>
+      <th scope="col">Default</th>
       <th scope="col">Last Edited</th>
       <th scope="col">Permissions</th>
       <th scope="col">Edit</th>
@@ -12,6 +13,7 @@
     <% @pages.each do |p| %>
       <tr>
         <td><%= link_to(p.title, page_path(p)) %> </td>
+        <td><%= p.default %></td>
         <td><%= "#{p.last_editor.full_name} on #{p.updated_at.strftime('%F')}" %></td>
         <td><%= p.viewer_permissions %></td>
         <td><%= link_to("Edit", edit_page_path(p), class: "btn btn-primary", id: "edit_#{p.url_slug}") %></td>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -10,6 +10,10 @@
   <label for="page_category" class="form-label">Category</label>
   <%= fields.text_field :category, class: "form-control" %>
 </div>
+<div class="form-group">
+  <label for="page_default" class="form-label">Default Page</label>
+  <%= fields.check_box :default %>
+</div>
 
 <div class="form-group">
   <label class="label-required form-label">Viewer Permissions</label>

--- a/features/pages_admin.feature
+++ b/features/pages_admin.feature
@@ -267,3 +267,18 @@ Scenario: Clicking radio button text selects that radio button
     Then The radio button "inlineRadioTeacher" should be checked
     And I choose "Public"
     Then The radio button "inlineRadioPublic" should be checked
+
+Scenario: Cannot update admin page to be default
+    Given I am on the new pages page
+    And I fill in "page_title" with "Test Default Title"
+    And I fill in "page_url_slug" with "test_slug"
+    And I choose "inlineRadioAdmin"
+    And I fill in the page HTML content with "This is a test"
+    And I press "Submit"
+    And I follow "Pages"
+    And I press the edit button for "test_slug"
+    Then I should be on the edit pages page for "test_slug"
+    And I check "page_default" checkbox
+    And I press "Update"
+    Then I should see "Update Test Default Title"
+    And I should see "error"

--- a/features/pages_admin.feature
+++ b/features/pages_admin.feature
@@ -119,6 +119,18 @@ Scenario: Can't create a page with a slug that already exists
     Then I should see "Create Test Title"
     And I should see "URL slug has already been taken"
 
+Scenario: Can't create a default admin page
+   Given I am on the new pages page
+    And I fill in "page_title" with "Test Title"
+    And I fill in "page_url_slug" with "test_slug"
+    And I fill in "page_category" with "Test Category"
+    And I check "page_default" checkbox
+    And I fill in the page HTML content with "This is a test"
+    And I choose "inlineRadioAdmin"
+    And I press "Submit"
+    Then I should see "Create Test Title"
+    And I should see "error"
+
 Scenario: Attempting to create page with taken slug doesn't delete form input
     Given I am on the new pages page
     And I fill in "page_title" with "Test Title"

--- a/features/pages_permissions.feature
+++ b/features/pages_permissions.feature
@@ -9,10 +9,11 @@ Background: Has admin and teacher in DB along with pages of each permission type
     | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   | Pending            |
     | Todd       | Teacher   | false | testteacher@berkeley.edu     | Validated          |
     Given the following pages exist:
-    | url_slug                   | title             | html               | viewer_permissions | category |
-    | test_slug_admin            | Test Admin Page   | Test admin body.   | Admin              | A        |
-    | test_slug_verified_teacher | Test Teacher Page | Test teacher body. | Verified Teacher   |          |
-    | test_slug_public           | Test Public Page  | Test public body.  | Public             | A        |
+    | url_slug                   | title             | html               | viewer_permissions | category | default |
+    | test_slug_admin            | Test Admin Page   | Test admin body.   | Admin              | A        |         |
+    | test_slug_verified_teacher | Test Teacher Page | Test teacher body. | Verified Teacher   |          |         |
+    | test_slug_public           | Test Public Page  | Test public body.  | Public             | A        |         |
+    | test_slug_public_default   | Default Public Page| Test default body.| Public             |          |  true   |
 
 Scenario: Admins can see everything
     Given I am on the BJC home page
@@ -47,10 +48,10 @@ Scenario: Teachers can't see admin pages, edit/delete button, or new page button
     And I should not see a button named "Edit"
     And I should not see a button named "New Page"
 
-Scenario: Public can only see public pages
+Scenario: Public should be redirected to default page, and can only see public pages in nav bar
     Given I am on the BJC home page
     Given I follow "Pages"
-    Then I should be on the pages index
+    Then I should see "Default Public Page"
     And I should see a nav link "A"
     And I should have a hidden page link "Test Public Page"
     And I should not have a hidden page link "Test Teacher Page"
@@ -119,7 +120,7 @@ Scenario: Teachers can't access admin pages
 Scenario: Public can access public pages
     Given I am on the BJC home page
     Then I follow "Pages"
-    Then I should be on the pages index
+    Then I should see "Default Public Page"
     And I follow the page link "Test Public Page"
     Then I should be on the page for slug "test_slug_public"
     And I should see "Test Public Page"

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -15,6 +15,10 @@ Given(/the following pages exist/) do |pages_table|
   end
 end
 
+When("I check {string} checkbox") do |checkbox|
+  check checkbox
+end
+
 When(/^(?:|I )fill in the page HTML content with "([^"]*)"$/) do |value|
   page.execute_script('$(tinyMCE.editors[0].setContent("' + value + '"))')
 end


### PR DESCRIPTION
Backend page model already has `default` column (I added a few weeks ago in another ticket).

This ticket:
-  updated page model validator to be able to update default page correctly (ensure there can only be 0 or 1 default page, default page must be public).
- changed edit form for page to contain a checkbox, so user can toggle default page.
- updated backend controller to redirect public user to a default page, if any.
- added and fixed relevant tests.