### PR TITLE
Teacher Application Status Splitted

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -22,6 +22,7 @@ class MainController < ApplicationController
 
   def dashboard
     @unvalidated_teachers = Teacher.unvalidated.order(:created_at) || []
+    @unreviewed_teachers = Teacher.unreviewed.order(:created_at) || []
     @validated_teachers = Teacher.validated.order(:created_at) || []
     @statuses = Teacher.validated.group(:status).order(count_all: :desc).count
     @schools = School.validated.order(teachers_count: :desc).limit(20)

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -7,11 +7,14 @@ class MainController < ApplicationController
     flash.keep
     if is_admin?
       redirect_to dashboard_path
+    # if this teacher is validated, redirect to pages
     elsif is_teacher? && current_user.validated?
       redirect_to pages_path, success: "Welcome back, #{current_user.first_name}!"
-    elsif is_teacher?
+    # if this teacher is not validated (not_reviewed or info_needed), redirect to edit
+    elsif is_teacher? && !current_user.validated?
       redirect_to edit_teacher_path(current_user.id),
                  alert: "Your applicating is currently #{current_user.application_status}. You may update your information."
+    # if this user is denied, redirect to new
     else
       redirect_to new_teacher_path
     end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -120,7 +120,9 @@ class TeachersController < ApplicationController
 
   def request_info
     @teacher.info_needed!
-    # Send email to user
+    if !params[:skip_email].present?
+      TeacherMailer.request_info_email(@teacher, params[:reason]).deliver_now
+    end
     redirect_to root_path
   end
 

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -28,7 +28,7 @@ class TeacherMailer < ApplicationMailer
   def form_submission(teacher)
     @teacher = teacher
     set_body
-    if @teacher.pending?
+    if @teacher.not_reviewed?
       mail to: CONTACT_EMAIL,
            subject: email_template.subject
     end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -25,6 +25,15 @@ class TeacherMailer < ApplicationMailer
          subject: email_template.subject
   end
 
+  def request_info_email(teacher, reason)
+    @teacher = teacher
+    @reason = reason
+    set_body
+    mail to: @teacher.email_name,
+         cc: CONTACT_EMAIL,
+         subject: email_template.subject
+  end
+
   def form_submission(teacher)
     @teacher = teacher
     set_body

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -6,7 +6,7 @@
 #
 #  id                 :integer          not null, primary key
 #  admin              :boolean          default(FALSE)
-#  application_status :string           default("pending")
+#  application_status :string           default("not_reviewed")
 #  education_level    :integer          default(NULL)
 #  email              :string
 #  first_name         :string
@@ -41,16 +41,19 @@ class Teacher < ApplicationRecord
   enum application_status: {
     validated: "Validated",
     denied: "Denied",
-    pending: "Pending"
+    info_needed: "Info Needed",
+    not_reviewed: "Not Reviewed",
   }
   validates_inclusion_of :application_status, in: application_statuses.keys
 
   belongs_to :school, counter_cache: true
 
-  # # Non-admin teachers who have not been denied nor accepted
-  scope :unvalidated, -> { where("application_status=? AND admin=?", application_statuses[:pending], "false") }
+  # Non-admin teachers whose application has neither been accepted nor denied
+  # It might or might not have been reviewed.
+  scope :unvalidated, -> { where("(application_status=? OR application_status=?) AND admin=?", application_statuses[:info_needed], application_statuses[:not_reviewed], "false") }
   # Non-admin teachers who have been accepted/validated
   scope :validated, -> { where("application_status=? AND admin=?", application_statuses[:validated], "false") }
+
 
   enum education_level: {
     middle_school: 0,
@@ -89,8 +92,8 @@ class Teacher < ApplicationRecord
 
   def reset_validation_status
     return if application_status_changed? || school_id_changed?
-    if denied?
-      pending!
+    if info_needed?
+      not_reviewed!
     end
   end
 
@@ -157,7 +160,8 @@ class Teacher < ApplicationRecord
     {
       validated: "✔️",
       denied: "🚫",
-      pending: "P"
+      not_reviewed: "✉️",
+      info_needed: "❓",
     }[application_status.to_sym]
   end
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -51,6 +51,7 @@ class Teacher < ApplicationRecord
   # Non-admin teachers whose application has neither been accepted nor denied
   # It might or might not have been reviewed.
   scope :unvalidated, -> { where("(application_status=? OR application_status=?) AND admin=?", application_statuses[:info_needed], application_statuses[:not_reviewed], "false") }
+  scope :unreviewed, -> { where("application_status=? AND admin=?", application_statuses[:not_reviewed], "false") }
   # Non-admin teachers who have been accepted/validated
   scope :validated, -> { where("application_status=? AND admin=?", application_statuses[:validated], "false") }
 

--- a/app/views/main/_deny_modal.html.erb
+++ b/app/views/main/_deny_modal.html.erb
@@ -2,12 +2,12 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title">Deny</h4>
+        <h4 class="modal-title"></h4>
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
       </div>
       <%= form_tag deny_teacher_path(0), method: :post, class: "form-horizontal" do %>
         <div class="modal-body">
-            <%= label_tag 'reason', 'Reason for Denial', class: 'control-label' %>
+            <%= label_tag 'reason', 'Reason', class: 'control-label' %>
             <%= text_field_tag :reason, params[:reason], class: "form-control" %>
             <div class="form-check">
               <%= check_box_tag :skip_email, 'skip_email', false, class: 'form-check-input' %>
@@ -28,12 +28,27 @@
   modal.on('shown.bs.modal', function (event) {
     let button = $(event.relatedTarget);
     let teacherId = button.data('teacher-id');
-    let teachername = button.data('teachername');
-    let newaction = `/teachers/${teacherId}/deny`;
-    modal.find('.form-horizontal').attr('action', newaction);
-    modal.find('.modal-title').text('Deny ' + teachername);
+    let teacherName = button.data('teacher-name');
+    let newAction = null;
+    let newTitle = null;
+    switch(button.data('modal-type')) {
+      case "deny":
+        newAction = `/teachers/${teacherId}/deny`;
+        newTitle = 'Deny ' + teacherName;
+        break;
+      case "request_info":
+        newAction = `/teachers/${teacherId}/request_info`;
+        newTitle = 'Request Info from ' + teacherName;
+        break;
+      default:
+        newAction = `/teachers/${teacherId}/deny`;
+        newTitle = 'Deny ' + teacherName;
+    }
+    modal.find('.form-horizontal').attr('action', newAction);
+    modal.find('.modal-title').text(newTitle);
   });
   modal.on('hidden.bs.modal', function () {
     $('input[name="reason"]').val('');
+    modal.find('.modal-title').text('');
   });
 </script>

--- a/app/views/main/dashboard.html.erb
+++ b/app/views/main/dashboard.html.erb
@@ -16,14 +16,13 @@
             <div class="btn-group" role="group" aria-label="Validate or Remove Teacher">
               <%= button_to("✔️", validate_teacher_path(teacher.id),
                  class: 'btn btn-outline-success', type: 'button') %>
+              <%= button_to("❓", request_info_teacher_path(teacher.id),
+                 class: 'btn btn-outline-warning', type: 'button') %>
               <span>
                 <button class="btn btn-outline-danger" type="button" data-toggle="modal" data-target=".js-denialModal" data-teacher-id="<%= teacher.id %>" data-teachername="<%= teacher.full_name %>">
                   ❌
                 </button>
               </span>
-              <%# <%= button_to("Delete", teacher_delete_path(teacher.id),
-                 data: {confirm: "Are you sure you wish to delete this form?"},
-                 class: 'btn btn-danger', type: 'button') %>
             </div>
           </td>
         </tr>

--- a/app/views/main/dashboard.html.erb
+++ b/app/views/main/dashboard.html.erb
@@ -9,17 +9,22 @@
         </tr>
       </thead>
       <tbody>
-        <% @unvalidated_teachers.each do |teacher| %>
+        <% @unreviewed_teachers.each do |teacher| %>
         <tr>
           <%= render 'teachers/teacher', teacher: teacher %>
           <td>
             <div class="btn-group" role="group" aria-label="Validate or Remove Teacher">
               <%= button_to("✔️", validate_teacher_path(teacher.id),
                  class: 'btn btn-outline-success', type: 'button') %>
-              <%= button_to("❓", request_info_teacher_path(teacher.id),
-                 class: 'btn btn-outline-warning', type: 'button') %>
               <span>
-                <button class="btn btn-outline-danger" type="button" data-toggle="modal" data-target=".js-denialModal" data-teacher-id="<%= teacher.id %>" data-teachername="<%= teacher.full_name %>">
+                <button class="btn btn-outline-warning" type="button" data-toggle="modal" data-target=".js-denialModal" 
+                  data-modal-type="request_info" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
+                  ❓
+                </button>
+              </span>
+              <span>
+                <button class="btn btn-outline-danger" type="button" data-toggle="modal" data-target=".js-denialModal" 
+                  data-modal-type="deny" data-teacher-id="<%= teacher.id %>" data-teacher-name="<%= teacher.full_name %>">
                   ❌
                 </button>
               </span>
@@ -29,9 +34,9 @@
         <% end %>
       </tbody>
     </table>
-    <% if @unvalidated_teachers.empty? %>
+    <% if @unreviewed_teachers.empty? %>
       <div class="alert alert-success" role="alert">
-        <strong>No pending forms!</strong>
+        <strong>No unreviewed forms!</strong>
       </div>
     <% end %>
 </div>

--- a/app/views/teachers/index.html.erb
+++ b/app/views/teachers/index.html.erb
@@ -10,8 +10,12 @@
   <label class="custom-control-label" for="Denied">Denied</label>
 </div>
 <div class="custom-control custom-checkbox custom-control-inline">
-  <input class="custom-control-input" type="checkbox" name="statusFilter" id="Pending" value="pending">
-  <label class="custom-control-label" for="Pending">Pending</label>
+  <input class="custom-control-input" type="checkbox" name="statusFilter" id="NotReviewed" value="not_reviewed">
+  <label class="custom-control-label" for="NotReviewed">Not Reviewed</label>
+</div>
+<div class="custom-control custom-checkbox custom-control-inline">
+  <input class="custom-control-input" type="checkbox" name="statusFilter" id="InfoNeeded" value="info_needed">
+  <label class="custom-control-label" for="InfoNeeded">Info Needed</label>
 </div>
 
 <table class="table table-striped js-dataTable js-teachersTable">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       post :resend_welcome_email
       post :validate
       post :deny
+      post :request_info
     end
     collection { post :import }
   end

--- a/db/migrate/20230415064901_change_default_teacher_application_status.rb
+++ b/db/migrate/20230415064901_change_default_teacher_application_status.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultTeacherApplicationStatus < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :teachers, :application_status, from: "Pending", to: "Not Reviewed"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_08_183157) do
+ActiveRecord::Schema.define(version: 2023_04_15_064901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 2023_03_08_183157) do
     t.boolean "admin", default: false
     t.string "personal_website"
     t.integer "education_level", default: -1
-    t.string "application_status", default: "Pending"
+    t.string "application_status", default: "Not Reviewed"
     t.datetime "last_session_at"
     t.inet "ip_history", default: [], array: true
     t.integer "session_count", default: 0

--- a/db/seed_data.rb
+++ b/db/seed_data.rb
@@ -31,6 +31,15 @@ module SeedData
     </p>
   DENY_EMAIL
 
+  @request_info_email = <<-REQUEST_INFO_EMAIL
+    <p>
+      Here is an update to your application to BJC: <br>
+      We need more information from you: <br>
+      {{ reason | strip_tags }} <br>
+      To update your application, please login to your account and update your application.
+    </p>
+  REQUEST_INFO_EMAIL
+
   def self.emails
     [
       {
@@ -65,6 +74,17 @@ module SeedData
         format: "html",
         title: "Deny Email",
         subject: "Deny Email"
+      },
+      {
+        id: 5,
+        body: @request_info_email,
+        path: "teacher_mailer/request_info_email",
+        locale: nil,
+        handler: "liquid",
+        partial: false,
+        format: "html",
+        title: "Request Info Email",
+        subject: "Request Info Email"
       }
     ]
   end

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -107,7 +107,7 @@ Scenario: Deny teacher as an admin
   When  I follow "Log In"
   Then  I can log in with Google
   And   I press "❌" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
-  Then  I should see "Reason for Denial"
+  Then  I should see "Reason"
   And   I should see "Deny Joseph Mamoa"
   And   I fill in "reason" with "Test"
   And   I press "Cancel"
@@ -116,6 +116,28 @@ Scenario: Deny teacher as an admin
   And   I fill in "reason" with "Denial Reason"
   And   I press "Submit"
   Then  I can send a deny email
+
+Scenario: Request info from teacher as an admin
+  Given the following schools exist:
+  | name        | city     | state | website                  | grade_level | school_type |
+  | UC Berkeley | Berkeley | CA    | https://www.berkeley.edu | university  | public      |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                    | school      |
+  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+  Given I am on the BJC home page
+  Given I have an admin email
+  When  I follow "Log In"
+  Then  I can log in with Google
+  And   I press "❓" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+  Then  I should see "Reason"
+  Then  I should see "Request Info from Joseph Mamoa"
+  And   I fill in "reason" with "Test"
+  And   I press "Cancel"
+  And   I press "❓" within "#DataTables_Table_0 > tbody > tr:nth-child(1)"
+  Then  the "reason" field should not contain "Test"
+  And   I fill in "reason" with "Request Info Reason"
+  And   I press "Submit"
+  Then  I can send a request info email
 
 Scenario: Not logged in should not have access to edit
   Given the following schools exist:

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -135,13 +135,13 @@ Scenario: Filter all teacher info as an admin
   | first_name | last_name  | admin | email                     | school      | application_status |
   | Victor     | Validateme | false | testteacher1@berkeley.edu | UC Berkeley |      Validated     |
   | Danny      | Denyme     | false | testteacher2@berkeley.edu | UC Berkeley |       Denied       |
-  | Peter      | Pendme     | false | testteacher3@berkeley.edu | UC Berkeley |       Pending      |
+  | Peter      | Pendme     | false | testteacher3@berkeley.edu | UC Berkeley |     Not Reviewed   |
   Given I am on the BJC home page
   Given I have an admin email
   And   I follow "Log In"
   Then  I can log in with Google
   When  I go to the teachers page
-  And   I check "Pending"
+  And   I check "Not Reviewed"
   And   I uncheck "Validated"
   Then  I should see "Peter"
   Then  I should not see "Victor"

--- a/features/pages_permissions.feature
+++ b/features/pages_permissions.feature
@@ -6,7 +6,7 @@ Background: Has admin and teacher in DB along with pages of each permission type
     Given I seed data
     Given the following teachers exist:
     | first_name | last_name | admin | email                        | application_status |
-    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   | Pending            |
+    | Joseph     | Mamoa     | true  | testadminuser@berkeley.edu   | Not Reviewed       |
     | Todd       | Teacher   | false | testteacher@berkeley.edu     | Validated          |
     Given the following pages exist:
     | url_slug                   | title             | html               | viewer_permissions | category | default |

--- a/features/school_form_submission.feature
+++ b/features/school_form_submission.feature
@@ -23,7 +23,7 @@ Scenario: Viewing the schools page should show the all current schools
     Then I can log in with Google
     And I am on the schools page
     # Berkeley already has 2 users.
-    Then I should see "UC Berkeley" with "5" in a table row
+    Then I should see "UC Berkeley" with "6" in a table row
     And I should see "UC Irvine" with "1" in a table row
     And I should see "UC Scam Diego" with "0" in a table row
 

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -60,6 +60,13 @@ Then(/I can send a deny email/) do
   last_email.body.encoded.should include "Denial Reason"
 end
 
+Then(/I can send a request info email/) do
+  last_email = ActionMailer::Base.deliveries.last
+  last_email.to[0].should eq "testteacher@berkeley.edu"
+  last_email.subject.should eq "Request Info Email"
+  last_email.body.encoded.should include "Request Info Reason"
+end
+
 Then(/I attach the csv "([^"]*)"$/) do |path|
   Capybara.ignore_hidden_elements = false
   attach_file("file", File.expand_path(path))

--- a/features/step_definitions/teacher_steps.rb
+++ b/features/step_definitions/teacher_steps.rb
@@ -52,7 +52,7 @@ Given(/the following teachers exist/) do |teachers_table|
     more_info: "I'm teaching a college course",
     admin: false,
     personal_website: "https://snap.berkeley.edu",
-    application_status: "Pending"
+    application_status: "Not Reviewed"
   }
 
   teachers_table.symbolic_hashes.each do |teacher|

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -91,7 +91,7 @@ Scenario: Logging in as a teacher with Snap account should be able to edit their
   And   I see a confirmation "You may update your information"
   Then  the "First Name" field should contain "Joseph"
 
-Scenario: Logged in pending teacher can update their info
+Scenario: Logged in teacher with Not_Reviewed application status can update their info
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
   |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
@@ -119,7 +119,7 @@ Scenario: Logged in pending teacher can update their info
   And   I am on the edit page for Joe Mamoa
 
   # TODO: Should this test updating to a new school?
-  Scenario: Logged in pending teacher cannot change Snap from new form path
+  Scenario: Logged in teacher with not_reviewed status cannot change Snap from new form path
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
   |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
@@ -159,7 +159,7 @@ Scenario: Logged in teacher can only edit their own information
   When I go to the edit page for Jane Austin
   Then I should see "You can only edit your own information"
 
-Scenario: Logging in as a pending teacher should see "Update" instead of "Submit" when editing info
+Scenario: Logging in as a teacher with not_reviewed status should see "Update" instead of "Submit" when editing info
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
   |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
@@ -187,6 +187,7 @@ Scenario: Frontend should not allow Teacher to edit their email
   When I go to the edit page for Jane Austin
   And  I enter my "School Email" as "wrong@berkeley.edu"
   And  I enter my "Snap! Username" as "wrong"
+  And I press "Update"
   Then the "School Email" field should contain "testteacher@berkeley.edu"
   Then the "Snap!" field should contain "Jane"
 
@@ -204,13 +205,13 @@ Scenario: Validated teacher should see resend button
   When I go to the edit page for Jane Austin
   Then I should see a button named "Resend Welcome Email"
 
-Scenario: Pending teacher should not see resend button
+Scenario: teacher with not_reviewed status should not see resend button
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
   |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                     | snap | application_status |
-  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | pending          |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | Not Reviewed       |
   Given I have a teacher Google email
   Given I am on the BJC home page
   And I follow "Log In"
@@ -232,6 +233,22 @@ Scenario: Denied teacher should not see resend button
   When I go to the edit page for Jane Austin
   Then I should not see "Resend Welcome Email"
 
+Scenario: Denied teacher cannot edit their information
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     | snap | application_status | more_info |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | denied | Original Information |
+  Given I have a teacher Google email
+  Given I am on the BJC home page
+  And I follow "Log In"
+  Then I can log in with Google
+  When I go to the edit page for Jane Austin
+  And  I enter my "More Information" as "Updated information"
+  And I press "Update"
+  Then the "More Information" field should contain "Original Information"
+
 Scenario: Validated teacher should not see Tags or NCES ID
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
@@ -247,13 +264,13 @@ Scenario: Validated teacher should not see Tags or NCES ID
   Then I should not see "Tags"
   And I should not see "NCES ID"
 
-Scenario: Pending teacher should not see Tags or NCES ID
+Scenario: Teacher with not_reviewed status should not see Tags or NCES ID
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |
   |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
   Given the following teachers exist:
   | first_name | last_name | admin | email                     | snap | application_status |
-  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | pending          |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane | Not Reviewed          |
   Given I have a teacher Google email
   Given I am on the BJC home page
   And I follow "Log In"

--- a/lib/tasks/split_teacher_pending_state.rake
+++ b/lib/tasks/split_teacher_pending_state.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :split_teacher_pending_state do
+  desc "Change all the pending state into not_reviewed state"
+  task :split => :environment do
+    Teacher.where(application_status: "pending").update_all(application_status: "not_reviewed")
+    Teacher.where(application_status: nil).update_all(application_status: "not_reviewed")
+  end
+end

--- a/lib/tasks/split_teacher_pending_state.rake
+++ b/lib/tasks/split_teacher_pending_state.rake
@@ -2,7 +2,7 @@
 
 namespace :split_teacher_pending_state do
   desc "Change all the pending state into not_reviewed state"
-  task :split => :environment do
+  task split: :environment do
     Teacher.where(application_status: "pending").update_all(application_status: "not_reviewed")
     Teacher.where(application_status: nil).update_all(application_status: "not_reviewed")
   end

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe TeachersController, type: :controller do
     expect(last_email.subject).to eq "Welcome to The Beauty and Joy of Computing!"
   end
 
-  it "denied and pending teacher can not request welcome email" do
+  it "denied and not_reviewed teacher can not request welcome email" do
     ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Bob"))
     bob_app = Teacher.find_by(first_name: "Bob")
     post :resend_welcome_email, params: { id: bob_app.id }

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -134,4 +134,14 @@ RSpec.describe TeachersController, type: :controller do
     post :resend_welcome_email, params: { id: short_app.id }
     expect(ActionMailer::Base.deliveries).to be_empty
   end
+
+  it "denied teacher cannot edit their application" do
+    ApplicationController.any_instance.stub(:is_admin?).and_return(false)
+    ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Bob"))
+    bob_app = Teacher.find_by(first_name: "Bob")
+    orig_more_info = bob_app.more_info
+    post :update, params: { id: bob_app.id, teacher: { id: bob_app.id, more_info: "changed", school_id: bob_app.school_id } }
+    bob_app = Teacher.find_by(first_name: "Bob")
+    expect(bob_app.more_info).to eq orig_more_info
+  end
 end

--- a/spec/fixtures/teachers.yml
+++ b/spec/fixtures/teachers.yml
@@ -4,7 +4,7 @@
 #
 #  id                 :integer          not null, primary key
 #  admin              :boolean          default(FALSE)
-#  application_status :string           default("pending")
+#  application_status :string           default("not_reviewed")
 #  education_level    :integer          default(NULL)
 #  email              :string
 #  first_name         :string
@@ -67,5 +67,17 @@ long:
   status: 3
   school: berkeley
   more_info: ''
-  application_status: Pending
+  application_status: Not Reviewed
   education_level: 2
+
+reimu:
+  id: 3
+  first_name: Reimu
+  last_name: Hakurei
+  snap: reimu
+  email: 'reimu@touhou.com'
+  status: 2
+  school: berkeley
+  more_info: ''
+  application_status: Info Needed
+  education_level: 1

--- a/spec/fixtures/teachers.yml
+++ b/spec/fixtures/teachers.yml
@@ -76,8 +76,8 @@ reimu:
   last_name: Hakurei
   snap: reimu
   email: 'reimu@touhou.com'
-  status: 2
+  status: 4
+  more_info: Best Touhou Character
   school: berkeley
-  more_info: ''
   application_status: Info Needed
-  education_level: 1
+  education_level: -1

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -46,5 +46,4 @@ describe TeacherMailer do
     expect(email.subject).to eq("Request Info Email")
     expect(email.body.encoded).to include("Request Info Reason")
   end
-  
 end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -36,4 +36,15 @@ describe TeacherMailer do
     expect(email.to[0]).to eq("lmock@berkeley.edu")
     expect(email.body.encoded).to include("Short Long")
   end
+
+  it "Sends Request Info Email" do
+    teacher = teachers(:long)
+    email = TeacherMailer.request_info_email(teacher, "Request Info Reason")
+    email.deliver_now
+    expect(email.from[0]).to eq("contact@bjc.berkeley.edu")
+    expect(email.to[0]).to eq("short@long.com")
+    expect(email.subject).to eq("Request Info Email")
+    expect(email.body.encoded).to include("Request Info Reason")
+  end
+  
 end

--- a/spec/malicious_spec.rb
+++ b/spec/malicious_spec.rb
@@ -47,6 +47,6 @@ RSpec.describe TeachersController, type: :controller do
             }
         }
     }
-    expect(Teacher.where(email: "valid_example@valid_example.edu").first.application_status).to eq("pending")
+    expect(Teacher.where(email: "valid_example@valid_example.edu").first.application_status).to eq("not_reviewed")
   end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -6,7 +6,7 @@
 #
 #  id                 :integer          not null, primary key
 #  admin              :boolean          default(FALSE)
-#  application_status :string           default("pending")
+#  application_status :string           default("not_reviewed")
 #  education_level    :integer          default(NULL)
 #  email              :string
 #  first_name         :string
@@ -65,12 +65,14 @@ RSpec.describe Teacher, type: :model do
     expect(teacher.display_education_level).to eq "?"
   end
 
-  context "updating a record" do
-    it "changes a denined status to pending" do
+  describe "teacher with info_needed application status" do
+    let(:teacher) { teachers(:reimu) }
+
+    it "changes a info_needed status to not_reviewed" do
       expect do
-        teacher.update(email: "bob.johnson@school.edu")
+        teacher.update(email: "reimu@touhou.com")
       end.to change(teacher, :application_status)
-             .from("denied").to("pending")
+             .from("info_needed").to("not_reviewed")
     end
   end
 
@@ -86,11 +88,15 @@ RSpec.describe Teacher, type: :model do
     end
   end
 
-  describe "teacher with pending application status" do
+  describe "teacher with not_reviewed application status" do
     let(:teacher) { teachers(:long) }
 
     it "shows an application status" do
-      expect(teacher.display_application_status).to eq "Pending"
+      expect(teacher.display_application_status).to eq "Not Reviewed"
     end
+
+    # it "can change a not_reviewed status to info_needed" do
+    #   expect do
+    #     teacher.update(email: "
   end
 end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -74,12 +74,21 @@ RSpec.describe Teacher, type: :model do
       end.to change(teacher, :application_status)
              .from("info_needed").to("not_reviewed")
     end
+
+    it "can change a not_reviewed status to info_needed" do
+      expect(teacher.more_info).to eq "Best Touhou Character"
+      expect do
+        teacher.update(more_info: "updated info")
+      end.to change(teacher, :more_info)
+              .from("Best Touhou Character").to("updated info")
+    end
   end
 
   describe "teacher with more info" do
     let(:teacher) { teachers(:ye) }
 
     it "shows a short status with more info" do
+      expect(teacher.more_info).to eq "A CS169 Student"
       expect(teacher.display_status).to eq "Other | A CS169 Student"
     end
 
@@ -94,9 +103,5 @@ RSpec.describe Teacher, type: :model do
     it "shows an application status" do
       expect(teacher.display_application_status).to eq "Not Reviewed"
     end
-
-    # it "can change a not_reviewed status to info_needed" do
-    #   expect do
-    #     teacher.update(email: "
   end
 end


### PR DESCRIPTION
Splitted the application status from three to four. The original `pending` state is further divided into two states: `not_reviewed` and `info_needed`. When an application is first created it is `not_reviewed`. Admin could mark it as `info_needed`. When the applicants actually edits and updates info it will be marked to `not_reviewed` again. When admin marks an application as `denied`, no further edit can be made from the applicant side.

Importantly, this ticket adds a rake task to migrate data. Use `rake split_teacher_pending_state:split` first to move all `pending` teacher row to `not_reviewed`. After you migrate data, you then migrate schema. (This PR contains the necessary migration file too). The remaining are modifications to MVC and tests.

TODO:
- Send an email when admin marks an application as `info_needed`. We probably should make an extra template and relevant frontend for admin to type details.