### PR TITLE
Make Dashboard View Use ENV Maps Key

### DIFF
--- a/app/views/main/dashboard.html.erb
+++ b/app/views/main/dashboard.html.erb
@@ -112,5 +112,5 @@
 </script>
 
 <script async defer
-        src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA9YjQt1uyBo0rEKe7UWMeW9GUryKtaMVo&callback=initMap">
+        src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap">
 </script>


### PR DESCRIPTION
The Dashboard view uses a hardcoded google maps API key. This change makes it use the google maps API key stored in .env.