### PR TITLE
Feature/school data cleanup debugging

### DIFF
--- a/app/views/schools/_form.html.erb
+++ b/app/views/schools/_form.html.erb
@@ -43,7 +43,7 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :grade_level, "Grade Level", for: "school_grade_level" %>
+  <%= f.label :grade_level, "Grade Level", class: "label-required", for: "school_grade_level" %>
   <%= f.select(
       :grade_level,
       options_for_select(School.grade_level_options, school.grade_level),
@@ -53,7 +53,7 @@
 </div>
 
 <div class="form-group">
-  <%= f.label :school_type, "School Type", for: 'school_type' %>
+  <%= f.label :school_type, "School Type", class: "label-required", for: 'school_type' %>
   <%= f.select(
       :school_type,
       options_for_select(School.school_type_options, school.school_type),

--- a/app/views/schools/new.html.erb
+++ b/app/views/schools/new.html.erb
@@ -1,5 +1,3 @@
-<%= provide(:h1, "Add a School") %>
-
 <%= form_for @school do |f| %>
   <%= render 'schools/form', f: f, school: @school %>
 

--- a/app/views/schools/new.html.erb
+++ b/app/views/schools/new.html.erb
@@ -1,3 +1,5 @@
+<%= provide(:h1, "Add a School") %>
+
 <%= form_for @school do |f| %>
   <%= render 'schools/form', f: f, school: @school %>
 

--- a/features/school_data_cleanup.feature
+++ b/features/school_data_cleanup.feature
@@ -1,0 +1,79 @@
+# ============================================================================
+# Cucumber feature: School Data Cleanup
+# ============================================================================
+#
+# These scenarios exercise the two rake tasks in
+# lib/tasks/school_data_cleanup.rake via end-to-end behavioral tests.
+#
+# Each scenario:
+#   1. Creates test data (via FactoryBot in the step definitions).
+#   2. Invokes a rake task with APPLY=true.
+#   3. Reloads the record and asserts the expected outcome.
+#
+# Note: all data is created in the Rails test database and cleaned up
+# by DatabaseCleaner between scenarios (configured in features/support/env.rb).
+# ============================================================================
+
+Feature: Fix school data
+  As an administrator
+  So that school records have accurate country and grade level information
+  I can run rake tasks to detect and fix data gaps
+
+  # --------------------------------------------------------------------------
+  # Country fix scenarios
+  # --------------------------------------------------------------------------
+
+  Scenario: A school with no country and a valid US state gets fixed
+    # A legacy school record has country=nil but state="CA".
+    # The fix_countries task should infer country="US" from the state.
+    Given a school "Berkeley Academy" exists with no country and state "CA"
+    When I run the rake task "schools:fix_countries"
+    Then the school "Berkeley Academy" should have country "US"
+
+  Scenario: A school's country is inferred from its website TLD
+    # A school with a .de (Germany) website and no state.
+    # The task should set country="DE" based on the top-level domain.
+    Given a school "Berlin Schule" exists with no country and website "https://www.schule.de"
+    When I run the rake task "schools:fix_countries"
+    Then the school "Berlin Schule" should have country "DE"
+
+  Scenario: A school with a valid country is not modified
+    # The task should leave already-correct records untouched.
+    Given a school "UC Berkeley" exists with country "US"
+    When I run the rake task "schools:fix_countries"
+    Then the school "UC Berkeley" should have country "US"
+
+  Scenario: A school that cannot be fixed is left unchanged
+    # A school with a .com website, no state, and no coordinates.
+    # None of the heuristics can determine the country.
+    Given a school "Mystery Academy" exists with no country and website "https://mystery.com"
+    When I run the rake task "schools:fix_countries"
+    Then the school "Mystery Academy" should have no country
+
+  # --------------------------------------------------------------------------
+  # Grade level fix scenarios
+  # --------------------------------------------------------------------------
+
+  Scenario: Grade level is fixed when name and teachers agree (high confidence)
+    # A school named "Springfield High School" is incorrectly set to elementary.
+    # Two linked teachers both report education_level=high_school.
+    # Both heuristics agree → high confidence → auto-fix.
+    Given a school "Springfield High School" exists with grade level "elementary"
+    And the school "Springfield High School" has 2 teachers with education level "high_school"
+    When I run the rake task "schools:fix_grade_levels"
+    Then the school "Springfield High School" should have grade level "high_school"
+
+  Scenario: Grade level is not auto-fixed with low confidence (name only)
+    # A school named "City Elementary" is set to high_school.
+    # The name suggests elementary, but there are no teachers to confirm.
+    # Low confidence → the task flags it but does not change the DB.
+    Given a school "City Elementary" exists with grade level "high_school"
+    When I run the rake task "schools:fix_grade_levels"
+    Then the school "City Elementary" should have grade level "high_school"
+
+  Scenario: A correctly-labeled school is not modified
+    # Name says "High School" and grade_level is already high_school.
+    # Nothing to fix.
+    Given a school "Oak High School" exists with grade level "high_school"
+    When I run the rake task "schools:fix_grade_levels"
+    Then the school "Oak High School" should have grade level "high_school"

--- a/features/step_definitions/school_data_cleanup_steps.rb
+++ b/features/step_definitions/school_data_cleanup_steps.rb
@@ -1,89 +1,45 @@
-# frozen_string_literal: true
 
-# ============================================================================
-# Step definitions for features/school_data_cleanup.feature
-# ============================================================================
-#
-# These steps:
-#   - Create test data with FactoryBot (using the :school and :teacher factories).
-#   - Use `update_column` to inject "bad" data that bypasses model validations,
-#     simulating the legacy production records the rake tasks are designed to fix.
-#   - Invoke the rake tasks programmatically with APPLY=true.
-#   - Reload records from the DB and assert the expected values.
-#
-# Convention: we store created schools in a @schools hash (keyed by name)
-# so that later steps can look them up without another DB query.
-# ============================================================================
 
-# Keep a hash of schools created during the scenario so "Then" steps can
-# find them by name without hitting the DB again unnecessarily.
 Before do
   @schools = {}
 end
 
-# ============================================================================
-# "Given" steps — create test data
-# ============================================================================
 
-# ---- Country-related Givens ------------------------------------------------
 
-# Creates a school with country set to nil and a specific US state.
-# Example: Given a school "Berkeley Academy" exists with no country and state "CA"
 Given(/^a school "([^"]*)" exists with no country and state "([^"]*)"$/) do |name, state|
-  # Create a valid school first (factory defaults country to "US").
   school = FactoryBot.create(:school, name: name, state: state)
 
-  # Now force country to nil directly in the DB, bypassing validations.
-  # This simulates a legacy record that predates the country column.
   school.update_column(:country, nil)
 
-  # Store the school so later steps can find it.
   @schools[name] = school
 end
 
-# Creates a school with country=nil, no state, and a specific website.
-# The website's TLD will be used by the task to infer the country.
-# Example: Given a school "Berlin Schule" exists with no country and website "https://www.schule.de"
 Given(/^a school "([^"]*)" exists with no country and website "([^"]*)"$/) do |name, website|
-  # Create with valid defaults first (state is required when country is US).
   school = FactoryBot.create(:school, name: name, website: website)
 
-  # Then simulate a legacy record by wiping country and state directly.
-  # We use update_column to bypass model validations.
   school.update_column(:country, nil)
   school.update_column(:state, nil)
-  # Also clear lat/lng so reverse geocoding won't kick in accidentally.
   school.update_column(:lat, nil)
   school.update_column(:lng, nil)
 
   @schools[name] = school
 end
 
-# Creates a school that already has a valid country — used to test the
-# "no-op" behavior (the task should leave it alone).
-# Example: Given a school "UC Berkeley" exists with country "US"
 Given(/^a school "([^"]*)" exists with country "([^"]*)"$/) do |name, country|
   school = FactoryBot.create(:school, name: name, country: country)
   @schools[name] = school
 end
 
-# ---- Grade-level-related Givens --------------------------------------------
 
-# Creates a school with a specific (possibly wrong) grade level.
-# Example: Given a school "Springfield High School" exists with grade level "elementary"
 Given(/^a school "([^"]*)" exists with grade level "([^"]*)"$/) do |name, grade_level|
   school = FactoryBot.create(:school, name: name, grade_level: grade_level.to_sym)
   @schools[name] = school
 end
 
-# Adds N teachers to an existing school, all with the given education_level.
-# This lets us set up the "teacher heuristic" data.
-# Example: And the school "Springfield High School" has 2 teachers with education level "high_school"
 Given(/^the school "([^"]*)" has (\d+) teachers with education level "([^"]*)"$/) do |name, count, level|
   school = @schools[name] || School.find_by!(name: name)
 
   count.to_i.times do |i|
-    # Each teacher needs a unique snap username (there's a unique index on it).
     FactoryBot.create(
       :teacher,
       school: school,
@@ -93,20 +49,10 @@ Given(/^the school "([^"]*)" has (\d+) teachers with education level "([^"]*)"$/
   end
 end
 
-# ============================================================================
-# "When" step — run the rake task
-# ============================================================================
 
-# Invokes the named rake task with APPLY=true so it actually writes to the DB.
-# After invoking we reenable the task so it can be invoked again in the next
-# scenario (Rake tasks are single-fire by default).
-# Example: When I run the rake task "schools:fix_countries"
 When(/^I run the rake task "([^"]*)"$/) do |task_name|
-  # Make sure Rake knows about our tasks.
-  # (Rails auto-loads tasks, but we load explicitly to be safe in test env.)
   Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
 
-  # Load the rake file if the task isn't already defined.
   unless Rake::Task.task_defined?(task_name)
     Rake.application.rake_require(
       "tasks/school_data_cleanup",
@@ -114,29 +60,19 @@ When(/^I run the rake task "([^"]*)"$/) do |task_name|
     )
   end
 
-  # Set APPLY=true so the task writes fixes to the DB.
   ENV["APPLY"] = "true"
 
-  # Invoke the task (capture stdout to keep cucumber output clean).
   Rake::Task[task_name].invoke
 
-  # Reenable so the next scenario can invoke the same task again.
   Rake::Task[task_name].reenable
 
-  # Clean up the env var.
   ENV.delete("APPLY")
 end
 
-# ============================================================================
-# "Then" steps — assert outcomes
-# ============================================================================
 
-# Asserts that the school's country column now equals the expected value.
-# Example: Then the school "Berkeley Academy" should have country "US"
 Then(/^the school "([^"]*)" should have country "([^"]*)"$/) do |name, expected_country|
   school = @schools[name] || School.find_by!(name: name)
 
-  # Reload from the DB so we see what the rake task actually wrote.
   school.reload
 
   expect(school.country).to eq(expected_country),
@@ -144,8 +80,6 @@ Then(/^the school "([^"]*)" should have country "([^"]*)"$/) do |name, expected_
     "but got '#{school.country}'"
 end
 
-# Asserts that the school's country is still nil (the task couldn't fix it).
-# Example: Then the school "Mystery Academy" should have no country
 Then(/^the school "([^"]*)" should have no country$/) do |name|
   school = @schools[name] || School.find_by!(name: name)
   school.reload
@@ -155,8 +89,6 @@ Then(/^the school "([^"]*)" should have no country$/) do |name|
     "but got '#{school.country}'"
 end
 
-# Asserts the school's grade_level enum value.
-# Example: Then the school "Springfield High School" should have grade level "high_school"
 Then(/^the school "([^"]*)" should have grade level "([^"]*)"$/) do |name, expected_level|
   school = @schools[name] || School.find_by!(name: name)
   school.reload

--- a/features/step_definitions/school_data_cleanup_steps.rb
+++ b/features/step_definitions/school_data_cleanup_steps.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+# ============================================================================
+# Step definitions for features/school_data_cleanup.feature
+# ============================================================================
+#
+# These steps:
+#   - Create test data with FactoryBot (using the :school and :teacher factories).
+#   - Use `update_column` to inject "bad" data that bypasses model validations,
+#     simulating the legacy production records the rake tasks are designed to fix.
+#   - Invoke the rake tasks programmatically with APPLY=true.
+#   - Reload records from the DB and assert the expected values.
+#
+# Convention: we store created schools in a @schools hash (keyed by name)
+# so that later steps can look them up without another DB query.
+# ============================================================================
+
+# Keep a hash of schools created during the scenario so "Then" steps can
+# find them by name without hitting the DB again unnecessarily.
+Before do
+  @schools = {}
+end
+
+# ============================================================================
+# "Given" steps — create test data
+# ============================================================================
+
+# ---- Country-related Givens ------------------------------------------------
+
+# Creates a school with country set to nil and a specific US state.
+# Example: Given a school "Berkeley Academy" exists with no country and state "CA"
+Given(/^a school "([^"]*)" exists with no country and state "([^"]*)"$/) do |name, state|
+  # Create a valid school first (factory defaults country to "US").
+  school = FactoryBot.create(:school, name: name, state: state)
+
+  # Now force country to nil directly in the DB, bypassing validations.
+  # This simulates a legacy record that predates the country column.
+  school.update_column(:country, nil)
+
+  # Store the school so later steps can find it.
+  @schools[name] = school
+end
+
+# Creates a school with country=nil, no state, and a specific website.
+# The website's TLD will be used by the task to infer the country.
+# Example: Given a school "Berlin Schule" exists with no country and website "https://www.schule.de"
+Given(/^a school "([^"]*)" exists with no country and website "([^"]*)"$/) do |name, website|
+  # Create with valid defaults first (state is required when country is US).
+  school = FactoryBot.create(:school, name: name, website: website)
+
+  # Then simulate a legacy record by wiping country and state directly.
+  # We use update_column to bypass model validations.
+  school.update_column(:country, nil)
+  school.update_column(:state, nil)
+  # Also clear lat/lng so reverse geocoding won't kick in accidentally.
+  school.update_column(:lat, nil)
+  school.update_column(:lng, nil)
+
+  @schools[name] = school
+end
+
+# Creates a school that already has a valid country — used to test the
+# "no-op" behavior (the task should leave it alone).
+# Example: Given a school "UC Berkeley" exists with country "US"
+Given(/^a school "([^"]*)" exists with country "([^"]*)"$/) do |name, country|
+  school = FactoryBot.create(:school, name: name, country: country)
+  @schools[name] = school
+end
+
+# ---- Grade-level-related Givens --------------------------------------------
+
+# Creates a school with a specific (possibly wrong) grade level.
+# Example: Given a school "Springfield High School" exists with grade level "elementary"
+Given(/^a school "([^"]*)" exists with grade level "([^"]*)"$/) do |name, grade_level|
+  school = FactoryBot.create(:school, name: name, grade_level: grade_level.to_sym)
+  @schools[name] = school
+end
+
+# Adds N teachers to an existing school, all with the given education_level.
+# This lets us set up the "teacher heuristic" data.
+# Example: And the school "Springfield High School" has 2 teachers with education level "high_school"
+Given(/^the school "([^"]*)" has (\d+) teachers with education level "([^"]*)"$/) do |name, count, level|
+  school = @schools[name] || School.find_by!(name: name)
+
+  count.to_i.times do |i|
+    # Each teacher needs a unique snap username (there's a unique index on it).
+    FactoryBot.create(
+      :teacher,
+      school: school,
+      education_level: level.to_sym,
+      snap: "#{name.parameterize}-teacher-#{i}"
+    )
+  end
+end
+
+# ============================================================================
+# "When" step — run the rake task
+# ============================================================================
+
+# Invokes the named rake task with APPLY=true so it actually writes to the DB.
+# After invoking we reenable the task so it can be invoked again in the next
+# scenario (Rake tasks are single-fire by default).
+# Example: When I run the rake task "schools:fix_countries"
+When(/^I run the rake task "([^"]*)"$/) do |task_name|
+  # Make sure Rake knows about our tasks.
+  # (Rails auto-loads tasks, but we load explicitly to be safe in test env.)
+  Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
+
+  # Load the rake file if the task isn't already defined.
+  unless Rake::Task.task_defined?(task_name)
+    Rake.application.rake_require(
+      "tasks/school_data_cleanup",
+      [Rails.root.join("lib").to_s]
+    )
+  end
+
+  # Set APPLY=true so the task writes fixes to the DB.
+  ENV["APPLY"] = "true"
+
+  # Invoke the task (capture stdout to keep cucumber output clean).
+  Rake::Task[task_name].invoke
+
+  # Reenable so the next scenario can invoke the same task again.
+  Rake::Task[task_name].reenable
+
+  # Clean up the env var.
+  ENV.delete("APPLY")
+end
+
+# ============================================================================
+# "Then" steps — assert outcomes
+# ============================================================================
+
+# Asserts that the school's country column now equals the expected value.
+# Example: Then the school "Berkeley Academy" should have country "US"
+Then(/^the school "([^"]*)" should have country "([^"]*)"$/) do |name, expected_country|
+  school = @schools[name] || School.find_by!(name: name)
+
+  # Reload from the DB so we see what the rake task actually wrote.
+  school.reload
+
+  expect(school.country).to eq(expected_country),
+    "Expected school '#{name}' to have country '#{expected_country}', " \
+    "but got '#{school.country}'"
+end
+
+# Asserts that the school's country is still nil (the task couldn't fix it).
+# Example: Then the school "Mystery Academy" should have no country
+Then(/^the school "([^"]*)" should have no country$/) do |name|
+  school = @schools[name] || School.find_by!(name: name)
+  school.reload
+
+  expect(school.country).to be_nil,
+    "Expected school '#{name}' to have no country (nil), " \
+    "but got '#{school.country}'"
+end
+
+# Asserts the school's grade_level enum value.
+# Example: Then the school "Springfield High School" should have grade level "high_school"
+Then(/^the school "([^"]*)" should have grade level "([^"]*)"$/) do |name, expected_level|
+  school = @schools[name] || School.find_by!(name: name)
+  school.reload
+
+  expect(school.grade_level).to eq(expected_level),
+    "Expected school '#{name}' to have grade_level '#{expected_level}', " \
+    "but got '#{school.grade_level}'"
+end

--- a/features/step_definitions/school_data_cleanup_steps.rb
+++ b/features/step_definitions/school_data_cleanup_steps.rb
@@ -1,13 +1,12 @@
 
+# frozen_string_literal: true
 
 Before do
   @schools = {}
 end
 
-
-
 Given(/^a school "([^"]*)" exists with no country and state "([^"]*)"$/) do |name, state|
-  school = FactoryBot.create(:school, name: name, state: state)
+  school = FactoryBot.create(:school, name:, state:)
 
   school.update_column(:country, nil)
 
@@ -15,7 +14,7 @@ Given(/^a school "([^"]*)" exists with no country and state "([^"]*)"$/) do |nam
 end
 
 Given(/^a school "([^"]*)" exists with no country and website "([^"]*)"$/) do |name, website|
-  school = FactoryBot.create(:school, name: name, website: website)
+  school = FactoryBot.create(:school, name:, website:)
 
   school.update_column(:country, nil)
   school.update_column(:state, nil)
@@ -26,23 +25,23 @@ Given(/^a school "([^"]*)" exists with no country and website "([^"]*)"$/) do |n
 end
 
 Given(/^a school "([^"]*)" exists with country "([^"]*)"$/) do |name, country|
-  school = FactoryBot.create(:school, name: name, country: country)
+  school = FactoryBot.create(:school, name:, country:)
   @schools[name] = school
 end
 
 
 Given(/^a school "([^"]*)" exists with grade level "([^"]*)"$/) do |name, grade_level|
-  school = FactoryBot.create(:school, name: name, grade_level: grade_level.to_sym)
+  school = FactoryBot.create(:school, name:, grade_level: grade_level.to_sym)
   @schools[name] = school
 end
 
 Given(/^the school "([^"]*)" has (\d+) teachers with education level "([^"]*)"$/) do |name, count, level|
-  school = @schools[name] || School.find_by!(name: name)
+  school = @schools[name] || School.find_by!(name:)
 
   count.to_i.times do |i|
     FactoryBot.create(
       :teacher,
-      school: school,
+      school:,
       education_level: level.to_sym,
       snap: "#{name.parameterize}-teacher-#{i}"
     )
@@ -71,7 +70,7 @@ end
 
 
 Then(/^the school "([^"]*)" should have country "([^"]*)"$/) do |name, expected_country|
-  school = @schools[name] || School.find_by!(name: name)
+  school = @schools[name] || School.find_by!(name:)
 
   school.reload
 
@@ -81,7 +80,7 @@ Then(/^the school "([^"]*)" should have country "([^"]*)"$/) do |name, expected_
 end
 
 Then(/^the school "([^"]*)" should have no country$/) do |name|
-  school = @schools[name] || School.find_by!(name: name)
+  school = @schools[name] || School.find_by!(name:)
   school.reload
 
   expect(school.country).to be_nil,
@@ -90,7 +89,7 @@ Then(/^the school "([^"]*)" should have no country$/) do |name|
 end
 
 Then(/^the school "([^"]*)" should have grade level "([^"]*)"$/) do |name, expected_level|
-  school = @schools[name] || School.find_by!(name: name)
+  school = @schools[name] || School.find_by!(name:)
   school.reload
 
   expect(school.grade_level).to eq(expected_level),

--- a/lib/tasks/school_data_cleanup.rake
+++ b/lib/tasks/school_data_cleanup.rake
@@ -1,0 +1,361 @@
+# frozen_string_literal: true
+
+# ============================================================================
+# School Data Cleanup Rake Tasks
+# ============================================================================
+#
+# These tasks help fix two common data-quality issues in production:
+#   1. Schools with a missing or invalid `country` value.
+#   2. Schools whose `grade_level` doesn't match what their teachers report
+#      or what their name implies.
+#
+# Both tasks are **dry-run by default** — they only print what they would
+# change. Pass APPLY=true to actually persist the fixes:
+#
+#   rails schools:fix_countries              # dry-run report
+#   rails schools:fix_countries APPLY=true   # apply fixes
+#
+#   rails schools:fix_grade_levels           # dry-run report
+#   rails schools:fix_grade_levels APPLY=true
+#
+# ============================================================================
+
+namespace :schools do
+
+  # --------------------------------------------------------------------------
+  # Task 1: Fix missing / invalid countries
+  # --------------------------------------------------------------------------
+  #
+  # Strategy (tried in order for each school):
+  #   a) If state is a valid US state abbreviation → country is "US".
+  #   b) Infer from the website's top-level domain (TLD):
+  #      e.g. .uk → "GB", .de → "DE", .ro → "RO".
+  #      Generic TLDs like .com / .org / .edu are skipped.
+  #   c) Reverse-geocode the school's lat/lng via the Google Maps API
+  #      (requires BACKEND_MAPS_API_KEY to be set).
+  #   d) If none of the above work, the school is listed as "unfixable"
+  #      so an admin can update it manually.
+  # --------------------------------------------------------------------------
+  desc "Report (and optionally fix) schools with missing or invalid country"
+  task fix_countries: :environment do
+    # Determine whether we're actually writing to the DB.
+    apply = ENV["APPLY"] == "true"
+
+    puts apply ? "\n=== APPLYING country fixes ===" : "\n=== DRY RUN — pass APPLY=true to save ==="
+    puts ""
+
+    # Build the set of valid ISO-3166 alpha-2 country codes for quick lookup.
+    # Example members: "US", "GB", "DE", "RO", …
+    valid_codes = ISO3166::Country.all.map(&:alpha2).to_set
+
+    # Also build the set of valid US state abbreviations so we can detect
+    # "this school is clearly in the US" even when country is blank.
+    us_states = School::VALID_STATES.to_set
+
+    # A list of generic TLDs that tell us nothing about the country.
+    generic_tlds = %w[com org edu net io gov mil int info].to_set
+
+    # Collect all schools whose country is NULL, empty, or not a valid code.
+    bad_schools = School.where(country: [nil, ""])
+                        .or(School.where.not(country: valid_codes.to_a))
+
+    puts "Found #{bad_schools.count} school(s) with missing/invalid country.\n\n"
+
+    # Counters for the summary at the end.
+    fixed   = 0
+    skipped = 0
+
+    bad_schools.find_each do |school|
+      proposed_country = nil
+      method_used      = nil
+
+      # --- Strategy (a): Check if the state looks like a US state -----------
+      if school.state.present? && us_states.include?(school.state.strip.upcase)
+        proposed_country = "US"
+        method_used = "US state abbreviation '#{school.state}'"
+      end
+
+      # --- Strategy (b): Infer from website TLD -----------------------------
+      # Only try if we haven't already found a country above.
+      if proposed_country.nil? && school.website.present?
+        begin
+          # Extract the hostname from the URL.  Example:
+          #   "https://www.school.ro/about" → "www.school.ro"
+          host = URI.parse(school.website).host
+          if host.present?
+            # The TLD is the last part after the final dot.
+            #   "www.school.ro" → "ro"
+            tld = host.split(".").last.upcase
+
+            # Only use the TLD if it's NOT a generic one and IS a valid code.
+            if !generic_tlds.include?(tld.downcase) && valid_codes.include?(tld)
+              proposed_country = tld
+              method_used = "website TLD '.#{tld.downcase}'"
+            end
+          end
+        rescue URI::InvalidURIError
+          # If the URL can't be parsed, just skip this strategy.
+        end
+      end
+
+      # --- Strategy (c): Reverse-geocode from lat/lng -----------------------
+      # Only try if we still don't have a country AND the school has coords.
+      if proposed_country.nil? && school.lat.present? && school.lng.present?
+        country_from_coords = reverse_geocode_country(school.lat, school.lng)
+        if country_from_coords && valid_codes.include?(country_from_coords)
+          proposed_country = country_from_coords
+          method_used = "reverse geocoding (#{school.lat}, #{school.lng})"
+        end
+      end
+
+      # --- Print result for this school -------------------------------------
+      if proposed_country
+        puts "  [FIX] ##{school.id} \"#{school.name}\" (#{school.city}, #{school.state})"
+        puts "         Current country: #{school.country.inspect}"
+        puts "         Proposed:        #{proposed_country}  (via #{method_used})"
+
+        if apply
+          # save(validate: false) because some legacy records may also be
+          # missing other required fields; we only want to fix country here.
+          school.update_column(:country, proposed_country)
+          puts "         ✓ Saved."
+        end
+
+        fixed += 1
+      else
+        # None of our heuristics could determine the country.
+        puts "  [SKIP] ##{school.id} \"#{school.name}\" (#{school.city}, #{school.state})"
+        puts "         website: #{school.website.inspect}  lat/lng: #{school.lat}, #{school.lng}"
+        puts "         ⚠ Could not infer country — needs manual review."
+        skipped += 1
+      end
+
+      puts ""
+    end
+
+    # --- Summary ------------------------------------------------------------
+    puts "---"
+    puts "Total:   #{bad_schools.count}"
+    puts "Fixable: #{fixed}   |   Needs manual review: #{skipped}"
+    puts apply ? "All fixable records have been updated." : "(Dry run — no changes written.)"
+    puts ""
+  end
+
+  # --------------------------------------------------------------------------
+  # Task 2: Fix inaccurate grade levels
+  # --------------------------------------------------------------------------
+  #
+  # Two heuristics are combined:
+  #
+  #   a) Name-based: If a school's name contains a keyword like "High School",
+  #      "Elementary", "Middle School", "Community College", or "University"
+  #      but its grade_level enum doesn't match, flag it.
+  #
+  #   b) Teacher-based: Look at the `education_level` of the teachers linked
+  #      to each school. If the **majority** of teachers indicate a different
+  #      level than the school's grade_level, flag the mismatch.
+  #
+  #      Mapping from Teacher.education_level → School.grade_level:
+  #        teacher middle_school (0)  →  school middle_school (1)
+  #        teacher high_school   (1)  →  school high_school   (2)
+  #        teacher college       (2)  →  school university    (4)
+  #
+  # Schools where both heuristics agree on a fix are labeled [HIGH CONFIDENCE].
+  # Schools where only one heuristic fires are labeled [LOW CONFIDENCE].
+  # --------------------------------------------------------------------------
+  desc "Report (and optionally fix) schools with likely-wrong grade levels"
+  task fix_grade_levels: :environment do
+    apply = ENV["APPLY"] == "true"
+
+    puts apply ? "\n=== APPLYING grade-level fixes ===" : "\n=== DRY RUN — pass APPLY=true to save ==="
+    puts ""
+
+    # This hash maps substrings in a school name to the expected grade_level
+    # enum key. The order matters: we check the most specific terms first so
+    # "Middle School" isn't accidentally matched by a later, broader rule.
+    name_keywords = {
+      "community college" => :community_college,
+      "university"        => :university,
+      "college"           => :university,        # "Boston College" etc.
+      "high school"       => :high_school,
+      "middle school"     => :middle_school,
+      "elementary"        => :elementary,
+      "primary school"    => :elementary,
+    }
+
+    # Maps a Teacher's education_level integer to the closest School grade_level
+    # symbol.  Teacher education_level enum: middle_school=0, high_school=1, college=2.
+    # School grade_level enum: elementary=0, middle_school=1, high_school=2,
+    #                          community_college=3, university=4.
+    teacher_to_school_grade = {
+      "middle_school" => :middle_school,   # teacher says middle school → school middle_school
+      "high_school"   => :high_school,     # teacher says high school   → school high_school
+      "college"       => :university,      # teacher says college       → school university
+    }
+
+    # Eager-load teachers to avoid N+1 queries when we inspect each school.
+    schools = School.includes(:teachers).order(:name)
+
+    puts "Scanning #{schools.count} school(s)...\n\n"
+
+    flagged = 0
+
+    schools.find_each do |school|
+      # Current grade level — may be nil for legacy records.
+      current_grade = school.grade_level  # e.g. "high_school" (string from enum)
+
+      # ------------------------------------------------------------------
+      # Heuristic (a): Check the school's name for grade-level keywords.
+      # ------------------------------------------------------------------
+      name_suggestion = nil
+      # Downcase the name once for case-insensitive matching.
+      lower_name = school.name.to_s.downcase
+      name_keywords.each do |keyword, grade_sym|
+        if lower_name.include?(keyword)
+          name_suggestion = grade_sym
+          break  # Stop at the first (most specific) match.
+        end
+      end
+
+      # ------------------------------------------------------------------
+      # Heuristic (b): Look at what the linked teachers say.
+      # ------------------------------------------------------------------
+      teacher_suggestion = nil
+
+      # Only consider teachers who actually have an education_level set
+      # (i.e., not nil and not the legacy default of -1).
+      teachers_with_level = school.teachers.select do |t|
+        t.education_level_before_type_cast.present? &&
+          t.education_level_before_type_cast.to_i >= 0
+      end
+
+      if teachers_with_level.any?
+        # Count how many teachers fall into each education_level category.
+        # Example result: { "high_school" => 5, "middle_school" => 1 }
+        level_counts = teachers_with_level
+          .group_by(&:education_level)    # group by the string label
+          .transform_values(&:count)      # count each group
+
+        # Find the level with the most teachers.
+        most_common_teacher_level = level_counts.max_by { |_level, count| count }&.first
+
+        # Map that teacher level to the corresponding school grade_level.
+        if most_common_teacher_level && teacher_to_school_grade.key?(most_common_teacher_level)
+          teacher_suggestion = teacher_to_school_grade[most_common_teacher_level]
+        end
+      end
+
+      # ------------------------------------------------------------------
+      # Decide whether to flag this school.
+      # ------------------------------------------------------------------
+      # We flag it if at least one heuristic suggests a DIFFERENT grade_level
+      # than what the school currently has.
+      name_mismatch    = name_suggestion    && name_suggestion.to_s    != current_grade
+      teacher_mismatch = teacher_suggestion && teacher_suggestion.to_s != current_grade
+
+      # Skip this school if neither heuristic found a problem.
+      next unless name_mismatch || teacher_mismatch
+
+      # Determine confidence: both heuristics agree → high; otherwise → low.
+      both_agree = name_mismatch && teacher_mismatch &&
+                   name_suggestion == teacher_suggestion
+      confidence = both_agree ? "HIGH" : "LOW"
+
+      # Pick the proposed fix. Prefer the value both agree on; otherwise,
+      # prefer the name-based suggestion (it's more deterministic).
+      proposed = if both_agree
+                   name_suggestion
+                 elsif name_mismatch
+                   name_suggestion
+                 else
+                   teacher_suggestion
+                 end
+
+      flagged += 1
+
+      # --- Print details for this school ----------------------------------
+      puts "  [#{confidence} CONFIDENCE] ##{school.id} \"#{school.name}\""
+      puts "    Current grade_level:  #{current_grade || '(nil)'}"
+      puts "    Proposed grade_level: #{proposed}"
+
+      if name_mismatch
+        puts "    ↳ Name contains keyword suggesting: #{name_suggestion}"
+      end
+
+      if teacher_mismatch
+        teacher_summary = teachers_with_level
+          .group_by(&:education_level)
+          .transform_values(&:count)
+          .map { |level, cnt| "#{level}=#{cnt}" }
+          .join(", ")
+        puts "    ↳ Teacher education levels (#{teachers_with_level.size} teachers): #{teacher_summary}"
+        puts "      Majority suggests school should be: #{teacher_suggestion}"
+      end
+
+      # Only auto-apply HIGH CONFIDENCE fixes to avoid incorrect updates.
+      if apply && both_agree
+        school.update_column(:grade_level, School.grade_levels[proposed])
+        puts "    ✓ Saved (high confidence)."
+      elsif apply
+        puts "    ⊘ Skipped (low confidence — review manually)."
+      end
+
+      puts ""
+    end
+
+    # --- Summary ------------------------------------------------------------
+    puts "---"
+    puts "Total schools scanned: #{schools.count}"
+    puts "Flagged:               #{flagged}"
+    puts apply ? "High-confidence fixes have been applied." : "(Dry run — no changes written.)"
+    puts ""
+  end
+end
+
+# ============================================================================
+# Helper: Reverse-geocode lat/lng → ISO alpha-2 country code
+# ============================================================================
+# Uses the same Google Maps API key the app already uses for forward geocoding
+# in MapsService. Returns nil if the key is missing or the API call fails.
+#
+# The Google Geocoding API response includes an array of address_components,
+# one of which has type "country". Its `short_name` is the ISO alpha-2 code.
+#
+# Example response fragment:
+#   { "short_name": "RO", "long_name": "Romania", "types": ["country", ...] }
+# ============================================================================
+def reverse_geocode_country(lat, lng)
+  api_key = ENV["BACKEND_MAPS_API_KEY"]
+
+  # If there's no API key configured, we can't call Google.
+  if api_key.blank?
+    # Only print this warning once so the output isn't flooded.
+    @_geo_warning_shown ||= begin
+      puts "  ⚠ BACKEND_MAPS_API_KEY is not set — skipping reverse geocoding."
+      true
+    end
+    return nil
+  end
+
+  # Build the reverse-geocoding URL.
+  # `latlng` param tells Google to do a reverse lookup.
+  url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{lng}&key=#{api_key}"
+
+  # Make the HTTP request (HTTParty is already a dependency of this app).
+  response = HTTParty.get(url)
+
+  # If the API didn't return a successful result, bail out.
+  return nil unless response["status"] == "OK"
+
+  # Dig into the first result's address components to find the one
+  # whose `types` array includes "country".
+  components = response.dig("results", 0, "address_components") || []
+  country_component = components.find { |c| c["types"].include?("country") }
+
+  # Return the ISO alpha-2 code (e.g. "US", "RO", "GB"), or nil.
+  country_component&.dig("short_name")
+rescue StandardError => e
+  # Network errors, JSON parse errors, etc. — don't crash the whole task.
+  puts "  ⚠ Reverse geocoding failed for (#{lat}, #{lng}): #{e.message}"
+  nil
+end

--- a/lib/tasks/school_data_cleanup.rake
+++ b/lib/tasks/school_data_cleanup.rake
@@ -1,67 +1,25 @@
-# frozen_string_literal: true
 
-# ============================================================================
-# School Data Cleanup Rake Tasks
-# ============================================================================
-#
-# These tasks help fix two common data-quality issues in production:
-#   1. Schools with a missing or invalid `country` value.
-#   2. Schools whose `grade_level` doesn't match what their teachers report
-#      or what their name implies.
-#
-# Both tasks are **dry-run by default** — they only print what they would
-# change. Pass APPLY=true to actually persist the fixes:
-#
-#   rails schools:fix_countries              # dry-run report
-#   rails schools:fix_countries APPLY=true   # apply fixes
-#
-#   rails schools:fix_grade_levels           # dry-run report
-#   rails schools:fix_grade_levels APPLY=true
-#
-# ============================================================================
 
 namespace :schools do
 
-  # --------------------------------------------------------------------------
-  # Task 1: Fix missing / invalid countries
-  # --------------------------------------------------------------------------
-  #
-  # Strategy (tried in order for each school):
-  #   a) If state is a valid US state abbreviation → country is "US".
-  #   b) Infer from the website's top-level domain (TLD):
-  #      e.g. .uk → "GB", .de → "DE", .ro → "RO".
-  #      Generic TLDs like .com / .org / .edu are skipped.
-  #   c) Reverse-geocode the school's lat/lng via the Google Maps API
-  #      (requires BACKEND_MAPS_API_KEY to be set).
-  #   d) If none of the above work, the school is listed as "unfixable"
-  #      so an admin can update it manually.
-  # --------------------------------------------------------------------------
   desc "Report (and optionally fix) schools with missing or invalid country"
   task fix_countries: :environment do
-    # Determine whether we're actually writing to the DB.
     apply = ENV["APPLY"] == "true"
 
     puts apply ? "\n=== APPLYING country fixes ===" : "\n=== DRY RUN — pass APPLY=true to save ==="
     puts ""
 
-    # Build the set of valid ISO-3166 alpha-2 country codes for quick lookup.
-    # Example members: "US", "GB", "DE", "RO", …
     valid_codes = ISO3166::Country.all.map(&:alpha2).to_set
 
-    # Also build the set of valid US state abbreviations so we can detect
-    # "this school is clearly in the US" even when country is blank.
     us_states = School::VALID_STATES.to_set
 
-    # A list of generic TLDs that tell us nothing about the country.
     generic_tlds = %w[com org edu net io gov mil int info].to_set
 
-    # Collect all schools whose country is NULL, empty, or not a valid code.
     bad_schools = School.where(country: [nil, ""])
                         .or(School.where.not(country: valid_codes.to_a))
 
     puts "Found #{bad_schools.count} school(s) with missing/invalid country.\n\n"
 
-    # Counters for the summary at the end.
     fixed   = 0
     skipped = 0
 
@@ -69,37 +27,26 @@ namespace :schools do
       proposed_country = nil
       method_used      = nil
 
-      # --- Strategy (a): Check if the state looks like a US state -----------
       if school.state.present? && us_states.include?(school.state.strip.upcase)
         proposed_country = "US"
         method_used = "US state abbreviation '#{school.state}'"
       end
 
-      # --- Strategy (b): Infer from website TLD -----------------------------
-      # Only try if we haven't already found a country above.
       if proposed_country.nil? && school.website.present?
         begin
-          # Extract the hostname from the URL.  Example:
-          #   "https://www.school.ro/about" → "www.school.ro"
           host = URI.parse(school.website).host
           if host.present?
-            # The TLD is the last part after the final dot.
-            #   "www.school.ro" → "ro"
             tld = host.split(".").last.upcase
 
-            # Only use the TLD if it's NOT a generic one and IS a valid code.
             if !generic_tlds.include?(tld.downcase) && valid_codes.include?(tld)
               proposed_country = tld
               method_used = "website TLD '.#{tld.downcase}'"
             end
           end
         rescue URI::InvalidURIError
-          # If the URL can't be parsed, just skip this strategy.
         end
       end
 
-      # --- Strategy (c): Reverse-geocode from lat/lng -----------------------
-      # Only try if we still don't have a country AND the school has coords.
       if proposed_country.nil? && school.lat.present? && school.lng.present?
         country_from_coords = reverse_geocode_country(school.lat, school.lng)
         if country_from_coords && valid_codes.include?(country_from_coords)
@@ -108,22 +55,18 @@ namespace :schools do
         end
       end
 
-      # --- Print result for this school -------------------------------------
       if proposed_country
         puts "  [FIX] ##{school.id} \"#{school.name}\" (#{school.city}, #{school.state})"
         puts "         Current country: #{school.country.inspect}"
         puts "         Proposed:        #{proposed_country}  (via #{method_used})"
 
         if apply
-          # save(validate: false) because some legacy records may also be
-          # missing other required fields; we only want to fix country here.
           school.update_column(:country, proposed_country)
           puts "         ✓ Saved."
         end
 
         fixed += 1
       else
-        # None of our heuristics could determine the country.
         puts "  [SKIP] ##{school.id} \"#{school.name}\" (#{school.city}, #{school.state})"
         puts "         website: #{school.website.inspect}  lat/lng: #{school.lat}, #{school.lng}"
         puts "         ⚠ Could not infer country — needs manual review."
@@ -133,7 +76,6 @@ namespace :schools do
       puts ""
     end
 
-    # --- Summary ------------------------------------------------------------
     puts "---"
     puts "Total:   #{bad_schools.count}"
     puts "Fixable: #{fixed}   |   Needs manual review: #{skipped}"
@@ -141,28 +83,6 @@ namespace :schools do
     puts ""
   end
 
-  # --------------------------------------------------------------------------
-  # Task 2: Fix inaccurate grade levels
-  # --------------------------------------------------------------------------
-  #
-  # Two heuristics are combined:
-  #
-  #   a) Name-based: If a school's name contains a keyword like "High School",
-  #      "Elementary", "Middle School", "Community College", or "University"
-  #      but its grade_level enum doesn't match, flag it.
-  #
-  #   b) Teacher-based: Look at the `education_level` of the teachers linked
-  #      to each school. If the **majority** of teachers indicate a different
-  #      level than the school's grade_level, flag the mismatch.
-  #
-  #      Mapping from Teacher.education_level → School.grade_level:
-  #        teacher middle_school (0)  →  school middle_school (1)
-  #        teacher high_school   (1)  →  school high_school   (2)
-  #        teacher college       (2)  →  school university    (4)
-  #
-  # Schools where both heuristics agree on a fix are labeled [HIGH CONFIDENCE].
-  # Schools where only one heuristic fires are labeled [LOW CONFIDENCE].
-  # --------------------------------------------------------------------------
   desc "Report (and optionally fix) schools with likely-wrong grade levels"
   task fix_grade_levels: :environment do
     apply = ENV["APPLY"] == "true"
@@ -170,30 +90,22 @@ namespace :schools do
     puts apply ? "\n=== APPLYING grade-level fixes ===" : "\n=== DRY RUN — pass APPLY=true to save ==="
     puts ""
 
-    # This hash maps substrings in a school name to the expected grade_level
-    # enum key. The order matters: we check the most specific terms first so
-    # "Middle School" isn't accidentally matched by a later, broader rule.
     name_keywords = {
       "community college" => :community_college,
       "university"        => :university,
-      "college"           => :university,        # "Boston College" etc.
+      "college"           => :university,
       "high school"       => :high_school,
       "middle school"     => :middle_school,
       "elementary"        => :elementary,
       "primary school"    => :elementary,
     }
 
-    # Maps a Teacher's education_level integer to the closest School grade_level
-    # symbol.  Teacher education_level enum: middle_school=0, high_school=1, college=2.
-    # School grade_level enum: elementary=0, middle_school=1, high_school=2,
-    #                          community_college=3, university=4.
     teacher_to_school_grade = {
-      "middle_school" => :middle_school,   # teacher says middle school → school middle_school
-      "high_school"   => :high_school,     # teacher says high school   → school high_school
-      "college"       => :university,      # teacher says college       → school university
+      "middle_school" => :middle_school,
+      "high_school"   => :high_school,
+      "college"       => :university,
     }
 
-    # Eager-load teachers to avoid N+1 queries when we inspect each school.
     schools = School.includes(:teachers).order(:name)
 
     puts "Scanning #{schools.count} school(s)...\n\n"
@@ -201,68 +113,45 @@ namespace :schools do
     flagged = 0
 
     schools.find_each do |school|
-      # Current grade level — may be nil for legacy records.
-      current_grade = school.grade_level  # e.g. "high_school" (string from enum)
+      current_grade = school.grade_level
 
-      # ------------------------------------------------------------------
-      # Heuristic (a): Check the school's name for grade-level keywords.
-      # ------------------------------------------------------------------
       name_suggestion = nil
-      # Downcase the name once for case-insensitive matching.
       lower_name = school.name.to_s.downcase
       name_keywords.each do |keyword, grade_sym|
         if lower_name.include?(keyword)
           name_suggestion = grade_sym
-          break  # Stop at the first (most specific) match.
+          break
         end
       end
 
-      # ------------------------------------------------------------------
-      # Heuristic (b): Look at what the linked teachers say.
-      # ------------------------------------------------------------------
       teacher_suggestion = nil
 
-      # Only consider teachers who actually have an education_level set
-      # (i.e., not nil and not the legacy default of -1).
       teachers_with_level = school.teachers.select do |t|
         t.education_level_before_type_cast.present? &&
           t.education_level_before_type_cast.to_i >= 0
       end
 
       if teachers_with_level.any?
-        # Count how many teachers fall into each education_level category.
-        # Example result: { "high_school" => 5, "middle_school" => 1 }
         level_counts = teachers_with_level
-          .group_by(&:education_level)    # group by the string label
-          .transform_values(&:count)      # count each group
+          .group_by(&:education_level)
+          .transform_values(&:count)
 
-        # Find the level with the most teachers.
         most_common_teacher_level = level_counts.max_by { |_level, count| count }&.first
 
-        # Map that teacher level to the corresponding school grade_level.
         if most_common_teacher_level && teacher_to_school_grade.key?(most_common_teacher_level)
           teacher_suggestion = teacher_to_school_grade[most_common_teacher_level]
         end
       end
 
-      # ------------------------------------------------------------------
-      # Decide whether to flag this school.
-      # ------------------------------------------------------------------
-      # We flag it if at least one heuristic suggests a DIFFERENT grade_level
-      # than what the school currently has.
       name_mismatch    = name_suggestion    && name_suggestion.to_s    != current_grade
       teacher_mismatch = teacher_suggestion && teacher_suggestion.to_s != current_grade
 
-      # Skip this school if neither heuristic found a problem.
       next unless name_mismatch || teacher_mismatch
 
-      # Determine confidence: both heuristics agree → high; otherwise → low.
       both_agree = name_mismatch && teacher_mismatch &&
                    name_suggestion == teacher_suggestion
       confidence = both_agree ? "HIGH" : "LOW"
 
-      # Pick the proposed fix. Prefer the value both agree on; otherwise,
-      # prefer the name-based suggestion (it's more deterministic).
       proposed = if both_agree
                    name_suggestion
                  elsif name_mismatch
@@ -273,7 +162,6 @@ namespace :schools do
 
       flagged += 1
 
-      # --- Print details for this school ----------------------------------
       puts "  [#{confidence} CONFIDENCE] ##{school.id} \"#{school.name}\""
       puts "    Current grade_level:  #{current_grade || '(nil)'}"
       puts "    Proposed grade_level: #{proposed}"
@@ -292,7 +180,6 @@ namespace :schools do
         puts "      Majority suggests school should be: #{teacher_suggestion}"
       end
 
-      # Only auto-apply HIGH CONFIDENCE fixes to avoid incorrect updates.
       if apply && both_agree
         school.update_column(:grade_level, School.grade_levels[proposed])
         puts "    ✓ Saved (high confidence)."
@@ -303,7 +190,6 @@ namespace :schools do
       puts ""
     end
 
-    # --- Summary ------------------------------------------------------------
     puts "---"
     puts "Total schools scanned: #{schools.count}"
     puts "Flagged:               #{flagged}"
@@ -312,24 +198,10 @@ namespace :schools do
   end
 end
 
-# ============================================================================
-# Helper: Reverse-geocode lat/lng → ISO alpha-2 country code
-# ============================================================================
-# Uses the same Google Maps API key the app already uses for forward geocoding
-# in MapsService. Returns nil if the key is missing or the API call fails.
-#
-# The Google Geocoding API response includes an array of address_components,
-# one of which has type "country". Its `short_name` is the ISO alpha-2 code.
-#
-# Example response fragment:
-#   { "short_name": "RO", "long_name": "Romania", "types": ["country", ...] }
-# ============================================================================
 def reverse_geocode_country(lat, lng)
   api_key = ENV["BACKEND_MAPS_API_KEY"]
 
-  # If there's no API key configured, we can't call Google.
   if api_key.blank?
-    # Only print this warning once so the output isn't flooded.
     @_geo_warning_shown ||= begin
       puts "  ⚠ BACKEND_MAPS_API_KEY is not set — skipping reverse geocoding."
       true
@@ -337,25 +209,17 @@ def reverse_geocode_country(lat, lng)
     return nil
   end
 
-  # Build the reverse-geocoding URL.
-  # `latlng` param tells Google to do a reverse lookup.
   url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{lng}&key=#{api_key}"
 
-  # Make the HTTP request (HTTParty is already a dependency of this app).
   response = HTTParty.get(url)
 
-  # If the API didn't return a successful result, bail out.
   return nil unless response["status"] == "OK"
 
-  # Dig into the first result's address components to find the one
-  # whose `types` array includes "country".
   components = response.dig("results", 0, "address_components") || []
   country_component = components.find { |c| c["types"].include?("country") }
 
-  # Return the ISO alpha-2 code (e.g. "US", "RO", "GB"), or nil.
   country_component&.dig("short_name")
 rescue StandardError => e
-  # Network errors, JSON parse errors, etc. — don't crash the whole task.
   puts "  ⚠ Reverse geocoding failed for (#{lat}, #{lng}): #{e.message}"
   nil
 end

--- a/lib/tasks/school_data_cleanup.rake
+++ b/lib/tasks/school_data_cleanup.rake
@@ -1,7 +1,7 @@
 
+# frozen_string_literal: true
 
 namespace :schools do
-
   desc "Report (and optionally fix) schools with missing or invalid country"
   task fix_countries: :environment do
     apply = ENV["APPLY"] == "true"
@@ -153,12 +153,12 @@ namespace :schools do
       confidence = both_agree ? "HIGH" : "LOW"
 
       proposed = if both_agree
-                   name_suggestion
-                 elsif name_mismatch
-                   name_suggestion
-                 else
-                   teacher_suggestion
-                 end
+        name_suggestion
+      elsif name_mismatch
+        name_suggestion
+      else
+        teacher_suggestion
+      end
 
       flagged += 1
 

--- a/spec/tasks/school_data_cleanup_spec.rb
+++ b/spec/tasks/school_data_cleanup_spec.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+# ============================================================================
+# RSpec tests for the school data cleanup rake tasks defined in
+# lib/tasks/school_data_cleanup.rake
+#
+# These tests verify two rake tasks:
+#   1) schools:fix_countries  — fixes missing/invalid country on schools
+#   2) schools:fix_grade_levels — fixes grade_level mismatches based on
+#      school name keywords and teacher education levels
+#
+# Key conventions used here:
+#   - FactoryBot creates test records (school, teacher).
+#   - We use `update_column` to set "bad" data directly in the DB,
+#     bypassing ActiveRecord validations that would normally prevent
+#     saving a school with country: nil, etc.
+#   - After running a rake task we call `record.reload` so we read
+#     the actual DB value, not a stale in-memory copy.
+#   - Each test calls `task.reenable` so the same task can be invoked
+#     multiple times across different examples.
+# ============================================================================
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "school_data_cleanup rake tasks" do
+  # --------------------------------------------------------------------------
+  # Load the rake file once for the entire describe block.
+  # Rails.application.load_tasks would load *all* tasks; instead we load
+  # only the file under test, which is faster and avoids side effects.
+  # --------------------------------------------------------------------------
+  before(:all) do
+    # Tell Rake about our application so it can resolve :environment.
+    Rake.application = Rake::Application.new
+
+    # Define the :environment task as a no-op.
+    # In production this boots Rails, but in tests Rails is already loaded.
+    Rake::Task.define_task(:environment)
+
+    # Load the rake file that contains the tasks we want to test.
+    Rake.application.rake_require(
+      "tasks/school_data_cleanup",     # path relative to lib/
+      [Rails.root.join("lib").to_s]    # tell Rake where to look
+    )
+  end
+
+  # --------------------------------------------------------------------------
+  # schools:fix_countries
+  # --------------------------------------------------------------------------
+  describe "schools:fix_countries" do
+    # Grab a reference to the task object so we can invoke and reenable it.
+    let(:task) { Rake::Task["schools:fix_countries"] }
+
+    # After every example, reenable the task.
+    # Rake tasks are "single-fire" by default — once invoked they won't
+    # run again unless you explicitly reenable them.
+    after(:each) { task.reenable }
+
+    # We must set APPLY=true so the task actually writes to the DB.
+    # Without it the task runs in dry-run mode and changes nothing.
+    around(:each) do |example|
+      # Temporarily set the environment variable for this test.
+      original = ENV["APPLY"]
+      ENV["APPLY"] = "true"
+      example.run
+    ensure
+      # Restore the previous value (usually nil) after the test.
+      ENV["APPLY"] = original
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: A school has country: nil but a valid US state.
+    # Expected: The task sets country to "US" via the state-abbreviation
+    #           heuristic (Strategy a).
+    # -----------------------------------------------------------------------
+    it "assigns 'US' to a school with nil country and a valid US state" do
+      # Create a normal school via the factory (country defaults to "US").
+      school = create(:school, state: "CA")
+
+      # Now force country to nil directly in the DB, skipping validations.
+      # This simulates a legacy record that predates the country column.
+      school.update_column(:country, nil)
+
+      # Sanity-check: make sure the DB actually has nil.
+      expect(school.reload.country).to be_nil
+
+      # Run the rake task (suppress puts output to keep test output clean).
+      expect { task.invoke }.to output.to_stdout
+
+      # Reload from DB and verify the task fixed the country.
+      school.reload
+      expect(school.country).to eq("US")
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: A school with country: nil and a .ro website TLD.
+    # Expected: The task sets country to "RO" via the TLD heuristic
+    #           (Strategy b).
+    # -----------------------------------------------------------------------
+    it "infers country from a non-generic website TLD" do
+      # Create a school with valid data first (state is required when country is US).
+      school = create(:school, website: "https://www.scoala.ro")
+
+      # Now simulate a legacy international record: wipe country AND state.
+      # We use update_column to bypass validations (state can't be nil for US schools).
+      school.update_column(:country, nil)
+      school.update_column(:state, nil)
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # "RO" is the ISO alpha-2 code for Romania.
+      expect(school.country).to eq("RO")
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: A school already has a valid country ("US").
+    # Expected: The task does NOT touch it — the record should remain
+    #           exactly as it was.
+    # -----------------------------------------------------------------------
+    it "does not modify a school that already has a valid country" do
+      school = create(:school, country: "US", state: "NY")
+
+      # Record the timestamp before the task runs.
+      original_updated_at = school.updated_at
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Country should still be "US".
+      expect(school.country).to eq("US")
+      # updated_at should be unchanged because update_column was never called.
+      expect(school.updated_at).to eq(original_updated_at)
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: A school has country: nil, a .com website, and no state.
+    # Expected: The task cannot infer the country (generic TLD + no state),
+    #           so the country stays nil.
+    # -----------------------------------------------------------------------
+    it "leaves country nil when no heuristic can determine it" do
+      # Create with valid data, then wipe country + state via update_column
+      # to simulate an unfixable legacy record.
+      school = create(:school, website: "https://example.com")
+
+      school.update_column(:country, nil)
+      school.update_column(:state, nil)
+      # Also clear lat/lng so reverse geocoding can't help either.
+      school.update_column(:lat, nil)
+      school.update_column(:lng, nil)
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Country should still be nil — the task couldn't fix it.
+      expect(school.country).to be_nil
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: Dry-run mode (APPLY is not "true").
+    # Expected: The task reports the problem but does NOT write to the DB.
+    # -----------------------------------------------------------------------
+    it "does not write changes in dry-run mode" do
+      school = create(:school, state: "CA")
+      school.update_column(:country, nil)
+
+      # Override the APPLY env var to something other than "true".
+      ENV["APPLY"] = "false"
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Country should still be nil because dry-run doesn't save.
+      expect(school.country).to be_nil
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # schools:fix_grade_levels
+  # --------------------------------------------------------------------------
+  describe "schools:fix_grade_levels" do
+    let(:task) { Rake::Task["schools:fix_grade_levels"] }
+
+    after(:each) { task.reenable }
+
+    around(:each) do |example|
+      original = ENV["APPLY"]
+      ENV["APPLY"] = "true"
+      example.run
+    ensure
+      ENV["APPLY"] = original
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: HIGH CONFIDENCE — both heuristics agree.
+    # A school named "Springfield High School" is set to elementary (0),
+    # and it has two teachers whose education_level is high_school (1).
+    # Both name keyword ("high school") and teacher majority point to
+    # high_school → the task should auto-fix it.
+    # -----------------------------------------------------------------------
+    it "fixes grade_level when both name and teacher heuristics agree (high confidence)" do
+      # Create a school named "Springfield High School" but with the
+      # wrong grade_level of :elementary.
+      school = create(:school, name: "Springfield High School", grade_level: :elementary)
+
+      # Create two teachers linked to this school, both teaching high school.
+      # education_level enum on Teacher: middle_school=0, high_school=1, college=2
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "teacher_hs_1")
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "teacher_hs_2")
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # The task should have corrected grade_level to :high_school (enum value 2).
+      expect(school.grade_level).to eq("high_school")
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: LOW CONFIDENCE — only the name heuristic fires.
+    # A school named "City Elementary" is set to high_school, but it has
+    # no teachers (or teachers with no education_level set).
+    # The name says "elementary" but with no teacher data to confirm,
+    # the task should flag it but NOT apply the fix.
+    # -----------------------------------------------------------------------
+    it "does not auto-fix when only the name heuristic fires (low confidence)" do
+      school = create(:school, name: "City Elementary", grade_level: :high_school)
+
+      # No teachers linked → teacher heuristic can't contribute.
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Grade level should remain unchanged because low-confidence fixes
+      # are not applied automatically.
+      expect(school.grade_level).to eq("high_school")
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: A school whose name and grade_level already match.
+    # Expected: The task should not flag or modify it.
+    # -----------------------------------------------------------------------
+    it "does not modify a school whose grade_level is already correct" do
+      school = create(:school, name: "Oak High School", grade_level: :high_school)
+
+      original_updated_at = school.updated_at
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      expect(school.grade_level).to eq("high_school")
+      expect(school.updated_at).to eq(original_updated_at)
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: Teacher-only mismatch (no name keyword).
+    # A school with a generic name "Learning Academy" is set to elementary,
+    # but all its teachers report education_level: high_school.
+    # Only the teacher heuristic fires → low confidence → no auto-fix.
+    # -----------------------------------------------------------------------
+    it "does not auto-fix when only teacher heuristic fires (low confidence)" do
+      school = create(:school, name: "Learning Academy", grade_level: :elementary)
+
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "hs_teacher_1")
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "hs_teacher_2")
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Should remain elementary — only one heuristic fired, so low confidence.
+      expect(school.grade_level).to eq("elementary")
+    end
+
+    # -----------------------------------------------------------------------
+    # Scenario: Dry-run mode for grade level fixes.
+    # Even with a high-confidence mismatch, nothing should be saved.
+    # -----------------------------------------------------------------------
+    it "does not write changes in dry-run mode" do
+      school = create(:school, name: "Springfield High School", grade_level: :elementary)
+
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "dry_run_teacher_1")
+      create(:teacher, school: school, education_level: :high_school,
+                       snap: "dry_run_teacher_2")
+
+      # Turn off APPLY so the task runs in dry-run mode.
+      ENV["APPLY"] = "false"
+
+      expect { task.invoke }.to output.to_stdout
+
+      school.reload
+      # Grade level should still be :elementary — dry run doesn't save.
+      expect(school.grade_level).to eq("elementary")
+    end
+  end
+end

--- a/spec/tasks/school_data_cleanup_spec.rb
+++ b/spec/tasks/school_data_cleanup_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "school_data_cleanup rake tasks" do
     it "does not modify a school that already has a valid country" do
       school = create(:school, country: "US", state: "NY")
 
+      school.reload
       original_updated_at = school.updated_at
 
       expect { task.invoke }.to output.to_stdout
@@ -132,6 +133,7 @@ RSpec.describe "school_data_cleanup rake tasks" do
     it "does not modify a school whose grade_level is already correct" do
       school = create(:school, name: "Oak High School", grade_level: :high_school)
 
+      school.reload
       original_updated_at = school.updated_at
 
       expect { task.invoke }.to output.to_stdout

--- a/spec/tasks/school_data_cleanup_spec.rb
+++ b/spec/tasks/school_data_cleanup_spec.rb
@@ -1,183 +1,97 @@
-# frozen_string_literal: true
 
-# ============================================================================
-# RSpec tests for the school data cleanup rake tasks defined in
-# lib/tasks/school_data_cleanup.rake
-#
-# These tests verify two rake tasks:
-#   1) schools:fix_countries  — fixes missing/invalid country on schools
-#   2) schools:fix_grade_levels — fixes grade_level mismatches based on
-#      school name keywords and teacher education levels
-#
-# Key conventions used here:
-#   - FactoryBot creates test records (school, teacher).
-#   - We use `update_column` to set "bad" data directly in the DB,
-#     bypassing ActiveRecord validations that would normally prevent
-#     saving a school with country: nil, etc.
-#   - After running a rake task we call `record.reload` so we read
-#     the actual DB value, not a stale in-memory copy.
-#   - Each test calls `task.reenable` so the same task can be invoked
-#     multiple times across different examples.
-# ============================================================================
 
 require "rails_helper"
 require "rake"
 
 RSpec.describe "school_data_cleanup rake tasks" do
-  # --------------------------------------------------------------------------
-  # Load the rake file once for the entire describe block.
-  # Rails.application.load_tasks would load *all* tasks; instead we load
-  # only the file under test, which is faster and avoids side effects.
-  # --------------------------------------------------------------------------
   before(:all) do
-    # Tell Rake about our application so it can resolve :environment.
     Rake.application = Rake::Application.new
 
-    # Define the :environment task as a no-op.
-    # In production this boots Rails, but in tests Rails is already loaded.
     Rake::Task.define_task(:environment)
 
-    # Load the rake file that contains the tasks we want to test.
     Rake.application.rake_require(
-      "tasks/school_data_cleanup",     # path relative to lib/
-      [Rails.root.join("lib").to_s]    # tell Rake where to look
+      "tasks/school_data_cleanup",
+      [Rails.root.join("lib").to_s]
     )
   end
 
-  # --------------------------------------------------------------------------
-  # schools:fix_countries
-  # --------------------------------------------------------------------------
   describe "schools:fix_countries" do
-    # Grab a reference to the task object so we can invoke and reenable it.
     let(:task) { Rake::Task["schools:fix_countries"] }
 
-    # After every example, reenable the task.
-    # Rake tasks are "single-fire" by default — once invoked they won't
-    # run again unless you explicitly reenable them.
     after(:each) { task.reenable }
 
-    # We must set APPLY=true so the task actually writes to the DB.
-    # Without it the task runs in dry-run mode and changes nothing.
     around(:each) do |example|
-      # Temporarily set the environment variable for this test.
       original = ENV["APPLY"]
       ENV["APPLY"] = "true"
       example.run
     ensure
-      # Restore the previous value (usually nil) after the test.
       ENV["APPLY"] = original
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: A school has country: nil but a valid US state.
-    # Expected: The task sets country to "US" via the state-abbreviation
-    #           heuristic (Strategy a).
-    # -----------------------------------------------------------------------
     it "assigns 'US' to a school with nil country and a valid US state" do
-      # Create a normal school via the factory (country defaults to "US").
       school = create(:school, state: "CA")
 
-      # Now force country to nil directly in the DB, skipping validations.
-      # This simulates a legacy record that predates the country column.
       school.update_column(:country, nil)
 
-      # Sanity-check: make sure the DB actually has nil.
       expect(school.reload.country).to be_nil
 
-      # Run the rake task (suppress puts output to keep test output clean).
       expect { task.invoke }.to output.to_stdout
 
-      # Reload from DB and verify the task fixed the country.
       school.reload
       expect(school.country).to eq("US")
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: A school with country: nil and a .ro website TLD.
-    # Expected: The task sets country to "RO" via the TLD heuristic
-    #           (Strategy b).
-    # -----------------------------------------------------------------------
     it "infers country from a non-generic website TLD" do
-      # Create a school with valid data first (state is required when country is US).
       school = create(:school, website: "https://www.scoala.ro")
 
-      # Now simulate a legacy international record: wipe country AND state.
-      # We use update_column to bypass validations (state can't be nil for US schools).
       school.update_column(:country, nil)
       school.update_column(:state, nil)
 
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # "RO" is the ISO alpha-2 code for Romania.
       expect(school.country).to eq("RO")
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: A school already has a valid country ("US").
-    # Expected: The task does NOT touch it — the record should remain
-    #           exactly as it was.
-    # -----------------------------------------------------------------------
     it "does not modify a school that already has a valid country" do
       school = create(:school, country: "US", state: "NY")
 
-      # Record the timestamp before the task runs.
       original_updated_at = school.updated_at
 
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Country should still be "US".
       expect(school.country).to eq("US")
-      # updated_at should be unchanged because update_column was never called.
       expect(school.updated_at).to eq(original_updated_at)
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: A school has country: nil, a .com website, and no state.
-    # Expected: The task cannot infer the country (generic TLD + no state),
-    #           so the country stays nil.
-    # -----------------------------------------------------------------------
     it "leaves country nil when no heuristic can determine it" do
-      # Create with valid data, then wipe country + state via update_column
-      # to simulate an unfixable legacy record.
       school = create(:school, website: "https://example.com")
 
       school.update_column(:country, nil)
       school.update_column(:state, nil)
-      # Also clear lat/lng so reverse geocoding can't help either.
       school.update_column(:lat, nil)
       school.update_column(:lng, nil)
 
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Country should still be nil — the task couldn't fix it.
       expect(school.country).to be_nil
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: Dry-run mode (APPLY is not "true").
-    # Expected: The task reports the problem but does NOT write to the DB.
-    # -----------------------------------------------------------------------
     it "does not write changes in dry-run mode" do
       school = create(:school, state: "CA")
       school.update_column(:country, nil)
 
-      # Override the APPLY env var to something other than "true".
       ENV["APPLY"] = "false"
 
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Country should still be nil because dry-run doesn't save.
       expect(school.country).to be_nil
     end
   end
 
-  # --------------------------------------------------------------------------
-  # schools:fix_grade_levels
-  # --------------------------------------------------------------------------
   describe "schools:fix_grade_levels" do
     let(:task) { Rake::Task["schools:fix_grade_levels"] }
 
@@ -191,20 +105,9 @@ RSpec.describe "school_data_cleanup rake tasks" do
       ENV["APPLY"] = original
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: HIGH CONFIDENCE — both heuristics agree.
-    # A school named "Springfield High School" is set to elementary (0),
-    # and it has two teachers whose education_level is high_school (1).
-    # Both name keyword ("high school") and teacher majority point to
-    # high_school → the task should auto-fix it.
-    # -----------------------------------------------------------------------
     it "fixes grade_level when both name and teacher heuristics agree (high confidence)" do
-      # Create a school named "Springfield High School" but with the
-      # wrong grade_level of :elementary.
       school = create(:school, name: "Springfield High School", grade_level: :elementary)
 
-      # Create two teachers linked to this school, both teaching high school.
-      # education_level enum on Teacher: middle_school=0, high_school=1, college=2
       create(:teacher, school: school, education_level: :high_school,
                        snap: "teacher_hs_1")
       create(:teacher, school: school, education_level: :high_school,
@@ -213,33 +116,18 @@ RSpec.describe "school_data_cleanup rake tasks" do
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # The task should have corrected grade_level to :high_school (enum value 2).
       expect(school.grade_level).to eq("high_school")
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: LOW CONFIDENCE — only the name heuristic fires.
-    # A school named "City Elementary" is set to high_school, but it has
-    # no teachers (or teachers with no education_level set).
-    # The name says "elementary" but with no teacher data to confirm,
-    # the task should flag it but NOT apply the fix.
-    # -----------------------------------------------------------------------
     it "does not auto-fix when only the name heuristic fires (low confidence)" do
       school = create(:school, name: "City Elementary", grade_level: :high_school)
 
-      # No teachers linked → teacher heuristic can't contribute.
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Grade level should remain unchanged because low-confidence fixes
-      # are not applied automatically.
       expect(school.grade_level).to eq("high_school")
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: A school whose name and grade_level already match.
-    # Expected: The task should not flag or modify it.
-    # -----------------------------------------------------------------------
     it "does not modify a school whose grade_level is already correct" do
       school = create(:school, name: "Oak High School", grade_level: :high_school)
 
@@ -252,12 +140,6 @@ RSpec.describe "school_data_cleanup rake tasks" do
       expect(school.updated_at).to eq(original_updated_at)
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: Teacher-only mismatch (no name keyword).
-    # A school with a generic name "Learning Academy" is set to elementary,
-    # but all its teachers report education_level: high_school.
-    # Only the teacher heuristic fires → low confidence → no auto-fix.
-    # -----------------------------------------------------------------------
     it "does not auto-fix when only teacher heuristic fires (low confidence)" do
       school = create(:school, name: "Learning Academy", grade_level: :elementary)
 
@@ -269,14 +151,9 @@ RSpec.describe "school_data_cleanup rake tasks" do
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Should remain elementary — only one heuristic fired, so low confidence.
       expect(school.grade_level).to eq("elementary")
     end
 
-    # -----------------------------------------------------------------------
-    # Scenario: Dry-run mode for grade level fixes.
-    # Even with a high-confidence mismatch, nothing should be saved.
-    # -----------------------------------------------------------------------
     it "does not write changes in dry-run mode" do
       school = create(:school, name: "Springfield High School", grade_level: :elementary)
 
@@ -285,13 +162,11 @@ RSpec.describe "school_data_cleanup rake tasks" do
       create(:teacher, school: school, education_level: :high_school,
                        snap: "dry_run_teacher_2")
 
-      # Turn off APPLY so the task runs in dry-run mode.
       ENV["APPLY"] = "false"
 
       expect { task.invoke }.to output.to_stdout
 
       school.reload
-      # Grade level should still be :elementary — dry run doesn't save.
       expect(school.grade_level).to eq("elementary")
     end
   end

--- a/spec/tasks/school_data_cleanup_spec.rb
+++ b/spec/tasks/school_data_cleanup_spec.rb
@@ -1,4 +1,5 @@
 
+# frozen_string_literal: true
 
 require "rails_helper"
 require "rake"
@@ -108,9 +109,9 @@ RSpec.describe "school_data_cleanup rake tasks" do
     it "fixes grade_level when both name and teacher heuristics agree (high confidence)" do
       school = create(:school, name: "Springfield High School", grade_level: :elementary)
 
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "teacher_hs_1")
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "teacher_hs_2")
 
       expect { task.invoke }.to output.to_stdout
@@ -143,9 +144,9 @@ RSpec.describe "school_data_cleanup rake tasks" do
     it "does not auto-fix when only teacher heuristic fires (low confidence)" do
       school = create(:school, name: "Learning Academy", grade_level: :elementary)
 
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "hs_teacher_1")
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "hs_teacher_2")
 
       expect { task.invoke }.to output.to_stdout
@@ -157,9 +158,9 @@ RSpec.describe "school_data_cleanup rake tasks" do
     it "does not write changes in dry-run mode" do
       school = create(:school, name: "Springfield High School", grade_level: :elementary)
 
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "dry_run_teacher_1")
-      create(:teacher, school: school, education_level: :high_school,
+      create(:teacher, school:, education_level: :high_school,
                        snap: "dry_run_teacher_2")
 
       ENV["APPLY"] = "false"


### PR DESCRIPTION
# What this PR does:

This pull request implements command-line school data cleanup scripts for missing or invalid school countries and inaccurate school grade levels, along with automated RSpec and Cucumber coverage for those workflows.

This debugging follow-up also includes the cleanup needed to get the new files aligned with the repository’s linting rules:
- adds the missing frozen string literal comments
- updates Ruby hash syntax to the preferred shorthand style
- fixes minor formatting and indentation issues flagged by RuboCop

These fixes do not change the intended behavior of the cleanup tasks; they make the branch pass linting more cleanly and keep the new test/support code consistent with the rest of the codebase.

Who authored this PR?

@hagenhaeussler

## How should this PR be tested?

- There is no deploy for this change. The main behavior is exercised through the rake tasks and their automated tests.
- Run the RSpec coverage for the rake tasks to verify the script logic around country cleanup and grade-level cleanup.
- Run the Cucumber coverage for the school data cleanup workflow to verify the end-to-end task behavior from test setup through persisted updates.
- Run RuboCop to confirm the new rake task, specs, and step definitions satisfy the repository’s linting requirements.

- For country cleanup, verify that schools with missing or invalid countries are corrected when the script can infer a country from:
  - a valid US state abbreviation
  - a non-generic website TLD
  - reverse geocoding from coordinates when available

- Also verify that the country script leaves records unchanged when:
  - the country is already valid
  - no heuristic can confidently determine the correct country
  - the task is run in dry-run mode

- For grade-level cleanup, verify that the script flags mismatches between a school's grade level and:
  - school-name keywords such as "High School", "Middle School", "Elementary", "College", or "University"
  - the majority education level of teachers linked to that school

- Verify that high-confidence grade-level matches can be applied, while low-confidence cases are surfaced for manual review instead of being automatically changed.

- Edge cases to watch:
  - generic website domains such as .com, .org, or .edu should not be used to infer country
  - malformed website URLs should not crash the task
  - schools with no usable teacher education-level data should not be auto-corrected from teacher-based logic
  - dry-run behavior should report proposed fixes without writing to the database
  - reverse geocoding depends on BACKEND_MAPS_API_KEY being present

Are there any complications to deploying this?

No schema changes or data migrations are included.

cc @armandofox @cycomachead @mdawn65 @ronikriger @kienthuynh @NishK05