### PR TITLE
Iteration 3 - Fix Cross Filter Search and Notice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "rails", "6.1.7.7"
 # Production app server
 gem "puma", "~> 5"
 gem "pg", "~> 1.5"
-gem "pg_search"
 
 # Front-end Assets
 gem "webpacker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,9 +351,6 @@ GEM
       racc
     path_expander (1.1.1)
     pg (1.5.3)
-    pg_search (2.3.7)
-      activerecord (>= 6.1)
-      activesupport (>= 6.1)
     pronto (0.11.1)
       gitlab (>= 4.4.0, < 5.0)
       httparty (>= 0.13.7, < 1.0)
@@ -595,7 +592,6 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth-yahoo-oauth2!
   pg (~> 1.5)
-  pg_search
   pronto
   pronto-flay
   pronto-haml

--- a/app/javascript/packs/datatables.js
+++ b/app/javascript/packs/datatables.js
@@ -22,6 +22,8 @@ $(function() {
   });
 
   $tables.draw();
+  const $teachersWrapper = $('.js-teachersTable').closest('.dataTables_wrapper');
+  $teachersWrapper.find('.dataTables_info').after($('#cross-filter-notice'));
   $(".custom-checkbox").on("change", () => {
       $tables.draw();
   });

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -39,24 +39,27 @@
 #  fk_rails_...  (school_id => schools.id)
 #
 class Teacher < ApplicationRecord
-  include PgSearch::Model
-
-  # Internal scope — callers use .search_non_admins which enforces admin: false.
-  # To search a new Teacher text column: add it to `against:`.
-  # To search a new association: add it to `associated_against:`.
-  pg_search_scope :_pg_search_teachers,
-    against: [:first_name, :last_name, :snap],
-    associated_against: {
-      email_addresses: :email,
-      school: :name
-    },
-    using: {
-      tsearch: { prefix: true, dictionary: "simple" },
-      trigram: { word_similarity: true }
-    }
-
   def self.search_non_admins(query)
-    where(admin: false)._pg_search_teachers(query)
+    q = "%#{sanitize_sql_like(query)}%"
+    status_case = statuses.map { |key, int|
+      "WHEN #{int} THEN '#{key.tr('_', ' ').titleize}'"
+    }.join(" ")
+
+    where(admin: false)
+      .left_joins(:email_addresses, :school)
+      .where(
+        "teachers.first_name ILIKE :q OR " \
+        "teachers.last_name ILIKE :q OR " \
+        "(teachers.first_name || ' ' || teachers.last_name) ILIKE :q OR " \
+        "teachers.snap ILIKE :q OR " \
+        "email_addresses.email ILIKE :q OR " \
+        "schools.name ILIKE :q OR " \
+        "teachers.application_status ILIKE :q OR " \
+        "(CASE teachers.status #{status_case} ELSE '' END) ILIKE :q OR " \
+        "TO_CHAR(teachers.created_at, 'MM/DD/YYYY') ILIKE :q",
+        q:
+      )
+      .distinct
   end
 
   # TODO: Move this somewhere else...

--- a/app/views/teachers/index.html.erb
+++ b/app/views/teachers/index.html.erb
@@ -14,7 +14,7 @@
 </div>
 <% end %>
 
-<div id="cross-filter-notice" class="text-muted small mb-2"></div>
+<div id="cross-filter-notice" class="text-muted small"></div>
 
 <table class="table table-striped js-dataTable js-teachersTable">
   <thead class="thead-dark">

--- a/app/views/teachers/index.html.erb
+++ b/app/views/teachers/index.html.erb
@@ -14,7 +14,7 @@
 </div>
 <% end %>
 
-<div id="cross-filter-notice" class="text-muted small"></div>
+<div id="cross-filter-notice" class="text-muted small w-100"></div>
 
 <table class="table table-striped js-dataTable js-teachersTable">
   <thead class="thead-dark">

--- a/db/migrate/20260328092348_enable_pg_trgm.rb
+++ b/db/migrate/20260328092348_enable_pg_trgm.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class EnablePgTrgm < ActiveRecord::Migration[6.1]
-  def change
-    enable_extension "pg_trgm"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_28_092348) do
+ActiveRecord::Schema.define(version: 2026_02_21_120000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
-  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "action_text_rich_texts", force: :cascade do |t|

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -169,5 +169,10 @@ RSpec.describe Teacher, type: :model do
     it "is case-insensitive" do
       expect(Teacher.search_non_admins("BOB")).to include(teachers(:bob))
     end
+
+    it "finds teachers by role" do
+      # teachers(:long) has status: 3 → display_status "Teals Volunteer"
+      expect(Teacher.search_non_admins("teals volunteer")).to include(teachers(:long))
+    end
   end
 end


### PR DESCRIPTION
> [!IMPORTANT]
> **PLEASE IGNORE THIS PR FOR NOW! DO NOT MERGE PLEASE!** 

**This PR does two main things:**
1. Moves the cross filter notice text below the standard results text: 
- <img width="1095" height="283" alt="image" src="https://github.com/user-attachments/assets/fa9a40aa-99bb-42da-9528-e5109e1029f2" />

2. Remove the pg_search gem and use a regular SQL query to get the number of hidden results. pg_search was too fine grain and often showed more results than the regular search function of Datatables. Now both searches return the same number of matches.

**Changes to schema/migrations:**
- Schema was rolled back to version right before pg_search was enabled and migration for pg_search was removed.

Fix is deployed to heroku for testing.