### PR TITLE
Fix personal email deletion confirm and last-email guard

### DIFF
--- a/app/controllers/email_addresses_controller.rb
+++ b/app/controllers/email_addresses_controller.rb
@@ -2,8 +2,8 @@
 
 class EmailAddressesController < ApplicationController
   before_action :require_login
-  before_action :require_admin
   before_action :set_teacher
+  before_action :require_email_edit_permission
 
   def create
     email = params[:email].to_s.strip
@@ -27,6 +27,11 @@ class EmailAddressesController < ApplicationController
       return
     end
 
+    if @teacher.email_addresses.count <= 1
+      redirect_to teacher_path(@teacher), alert: "Add another email before deleting this one."
+      return
+    end
+
     email.destroy!
     redirect_to teacher_path(@teacher), notice: "Email address deleted successfully."
   rescue ActiveRecord::RecordNotFound
@@ -38,5 +43,11 @@ class EmailAddressesController < ApplicationController
   private
   def set_teacher
     @teacher = Teacher.find(params[:teacher_id])
+  end
+
+  def require_email_edit_permission
+    return if is_admin? || current_user.id == @teacher.id
+
+    redirect_to edit_teacher_path(current_user.id), alert: "You can only edit your own information"
   end
 end

--- a/app/views/teachers/_teacher_info.html.erb
+++ b/app/views/teachers/_teacher_info.html.erb
@@ -42,7 +42,8 @@
               <% if @is_admin || @is_teacher %>
                 <%= link_to teacher_delete_email_address_path(teacher, email),
                             method: :delete,
-                            onclick: "return confirm('Are you sure you want to delete this email?')",
+                            onclick: "return validateEmailDeletion(this);",
+                            data: { confirm: "Are you sure you want to delete this email?" },
                             class: "btn btn-sm btn-link text-danger delete-email-btn p-0 ml-1" do %>
                   <i class="fa fa-times"></i>
                 <% end %>
@@ -166,5 +167,36 @@
 
     // Remove the temporary element
     document.body.removeChild(textarea);
+  }
+
+  if (window.validateEmailDeletion === undefined) {
+    window.validateEmailDeletion = function(linkElement) {
+      const cardBody = linkElement.closest(".card-body");
+      if (!cardBody) return true;
+
+      const emailCount = cardBody.querySelectorAll(".email-list-item").length;
+      const existingAlert = cardBody.querySelector(".email-delete-error");
+
+      if (emailCount <= 1) {
+        if (!existingAlert) {
+          const alertElement = document.createElement("div");
+          alertElement.className = "alert alert-danger alert-dismissible email-delete-error";
+          alertElement.setAttribute("role", "alert");
+          alertElement.innerHTML = `
+            <button type="button" class="close" data-dismiss="alert" aria-label="Dismiss">
+              <span aria-hidden="true">✖️</span>
+            </button>
+            Add another email before deleting this one.
+          `;
+          cardBody.appendChild(alertElement);
+        }
+        return false;
+      }
+
+      if (existingAlert) {
+        existingAlert.remove();
+      }
+      return true;
+    };
   }
 </script>


### PR DESCRIPTION
Fixes Bugs Caught in the discussion related to deleting emails and also not allowing teachers or admins to leave teachers with no emails.

Issue 1: On the confirm delete page, even if you clicked cancel, the email would be deleted
-fixes the logic for delete
Issue 2: You could delete a teacher's only email and leave them with no contact info
-added a client and server-side check to ensure 1 email is always stored.